### PR TITLE
Update to the HEM correction

### DIFF
--- a/preselection/src/corrections.cpp
+++ b/preselection/src/corrections.cpp
@@ -72,7 +72,7 @@ RNode HEMCorrection(RNode df, bool isData) {
         // Need to check if there is dependence on jet ID in v15
         auto eta_ = eta[jet_mask];
         auto phi_ = phi[jet_mask];
-        if (sample_year == "2018" && ((isData && run >= 319077) || (!isData && event % 1961 < 1286))) {
+        if (sample_year == "2018" && ((isData && run >= 319077) || (!isData && event % 100 < 64))) {
             for (size_t i = 0; i < eta_.size(); i++) {
                 if (eta_[i] > -3.2 && eta_[i] < -1.3 && phi_[i] > -1.57 && phi_[i] < -0.87) {
                     return false;


### PR DESCRIPTION
This PR updates the handling of the HEM correction.

### Description of original handling:
For events that have jets that fall into the eta-phi region affected by the HEM issue (hereafter known as the "HEM issue region" in this PR), the current logic vetos events according to the following logic:
```
event % 1961 < 1286
``` 
This aims to veto about 66% of events (that have jets in the HEM issue region). However, the signal sample are generated in batches of 100, so the event numbers are always 100 or less. This means that for signal, 100% of the signal events (that have jets in the HEM issue region) are killed by this logic. 

The overall effect is that about 17% of the signal events (in 2018) are killed. 

### Description of new handling:

This PR modifies the logic to be:
```
(!isData && event % 100 < 64)
```
This logic will remove the target faction of events (including for the case of our signal, which has run numbers that only reach up to 100).

One thing to note is that the target fraction in this updated implementation is 64% (as opposed to the 66% target in the original implementation). This target number was found by checking what fraction of events are in runs 319077 or above in an example 2018 dataset (`SingleMuon`). This target number is similar to the 66% in the original implementation (which had an unknown source, but was likely based on some luminosity comparison). Since the source of the derivation of this new target number is known, we choose to move to it for now. 

With this updated handling in place, the overall effect is that the 2018 signal drops by about 11% from the application of this HEM correction. 
