### PR TITLE
use 2024 b-tagging wps for 22/23 & add back met filters

### DIFF
--- a/preselection/src/corrections.h
+++ b/preselection/src/corrections.h
@@ -33,6 +33,10 @@ const std::unordered_map <std::string, correction::CorrectionSet> btaggingCorrec
     {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run2-2016postVFP-UL-NanoAODv15/add_b_tagging_WPs/btagging.json.gz")},
     {"2017", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run2-2017-UL-NanoAODv15/add_b_tagging_WPs/btagging.json.gz")},
     {"2018", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run2-2018-UL-NanoAODv15/add_b_tagging_WPs/btagging.json.gz")},
+    {"2022Re-recoBCD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/latest/btagging.json.gz")},
+    {"2022Re-recoE+PromptFG", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/latest/btagging.json.gz")},
+    {"2023PromptC", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/latest/btagging.json.gz")},
+    {"2023PromptD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/latest/btagging.json.gz")},
     {"2024Prompt", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/latest/btagging.json.gz")}
 };
 
@@ -42,6 +46,10 @@ static std::unordered_map<std::string, float> btaggingWPMap_Loose = {
     {"2016postVFP", btaggingCorrections.at("2016postVFP").at("UParTAK4_wp_values")->evaluate({"L"})},
     {"2017",        btaggingCorrections.at("2017").at("UParTAK4_wp_values")->evaluate({"L"})},
     {"2018",        btaggingCorrections.at("2018").at("UParTAK4_wp_values")->evaluate({"L"})},
+    {"2022Re-recoBCD", btaggingCorrections.at("2022Re-recoBCD").at("UParTAK4_wp_values")->evaluate({"L"})},
+    {"2022Re-recoE+PromptFG", btaggingCorrections.at("2022Re-recoE+PromptFG").at("UParTAK4_wp_values")->evaluate({"L"})},
+    {"2023PromptC", btaggingCorrections.at("2023PromptC").at("UParTAK4_wp_values")->evaluate({"L"})},
+    {"2023PromptD", btaggingCorrections.at("2023PromptD").at("UParTAK4_wp_values")->evaluate({"L"})},
     {"2024Prompt",  btaggingCorrections.at("2024Prompt").at("UParTAK4_wp_values")->evaluate({"L"})}
 };
 
@@ -50,6 +58,10 @@ static std::unordered_map<std::string, float> btaggingWPMap_Medium = {
     {"2016postVFP", btaggingCorrections.at("2016postVFP").at("UParTAK4_wp_values")->evaluate({"M"})},
     {"2017",        btaggingCorrections.at("2017").at("UParTAK4_wp_values")->evaluate({"M"})},
     {"2018",        btaggingCorrections.at("2018").at("UParTAK4_wp_values")->evaluate({"M"})},
+    {"2022Re-recoBCD", btaggingCorrections.at("2022Re-recoBCD").at("UParTAK4_wp_values")->evaluate({"M"})},
+    {"2022Re-recoE+PromptFG", btaggingCorrections.at("2022Re-recoE+PromptFG").at("UParTAK4_wp_values")->evaluate({"M"})},
+    {"2023PromptC", btaggingCorrections.at("2023PromptC").at("UParTAK4_wp_values")->evaluate({"M"})},
+    {"2023PromptD", btaggingCorrections.at("2023PromptD").at("UParTAK4_wp_values")->evaluate({"M"})},
     {"2024Prompt",  btaggingCorrections.at("2024Prompt").at("UParTAK4_wp_values")->evaluate({"M"})}
 };
 
@@ -58,6 +70,10 @@ static std::unordered_map<std::string, float> btaggingWPMap_Tight = {
     {"2016postVFP", btaggingCorrections.at("2016postVFP").at("UParTAK4_wp_values")->evaluate({"T"})},
     {"2017",        btaggingCorrections.at("2017").at("UParTAK4_wp_values")->evaluate({"T"})},
     {"2018",        btaggingCorrections.at("2018").at("UParTAK4_wp_values")->evaluate({"T"})},
+    {"2022Re-recoBCD", btaggingCorrections.at("2022Re-recoBCD").at("UParTAK4_wp_values")->evaluate({"T"})},
+    {"2022Re-recoE+PromptFG", btaggingCorrections.at("2022Re-recoE+PromptFG").at("UParTAK4_wp_values")->evaluate({"T"})},
+    {"2023PromptC", btaggingCorrections.at("2023PromptC").at("UParTAK4_wp_values")->evaluate({"T"})},
+    {"2023PromptD", btaggingCorrections.at("2023PromptD").at("UParTAK4_wp_values")->evaluate({"T"})},
     {"2024Prompt",  btaggingCorrections.at("2024Prompt").at("UParTAK4_wp_values")->evaluate({"T"})}
 };
 
@@ -71,10 +87,10 @@ const std::unordered_map<std::string, correction::CorrectionSet> metCorrections 
     {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016postVFP-UL-NanoAODv9/latest/met.json.gz")},
     {"2017", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2017-UL-NanoAODv9/latest/met.json.gz")},
     {"2018", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2018-UL-NanoAODv9/latest/met.json.gz")},
-    {"2022Re-recoBCD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/latest/met_xyCorrections_2022_2022.json.gz")},
-    {"2022Re-recoE+PromptFG", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22EFGSep23-Summer22EE-NanoAODv12/latest/met_xyCorrections_2022_2022EE.json.gz")},
-    {"2023PromptC", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23CSep23-Summer23-NanoAODv12/latest/met_xyCorrections_2023_2023.json.gz")},
-    {"2023PromptD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23DSep23-Summer23BPix-NanoAODv12/latest/met_xyCorrections_2023_2023BPix.json.gz")}
+    // {"2022Re-recoBCD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/latest/met_xyCorrections_2022_2022.json.gz")},
+    // {"2022Re-recoE+PromptFG", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22EFGSep23-Summer22EE-NanoAODv12/latest/met_xyCorrections_2022_2022EE.json.gz")},
+    // {"2023PromptC", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23CSep23-Summer23-NanoAODv12/latest/met_xyCorrections_2023_2023.json.gz")},
+    // {"2023PromptD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23DSep23-Summer23BPix-NanoAODv12/latest/met_xyCorrections_2023_2023BPix.json.gz")}
 };
 RNode applyMETPhiCorrections(RNode df, bool isData);
 RNode applyMETUnclusteredCorrections(RNode df, std::string variation);

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -1,6 +1,27 @@
 #include "selections.h"
 #include "cutflow.h"
 
+RNode METFilters(RNode df_) {
+    return df_.Filter("(isRun3 && (Flag_goodVertices && "
+            "Flag_globalSuperTightHalo2016Filter && "
+            "Flag_EcalDeadCellTriggerPrimitiveFilter && "
+            "Flag_BadPFMuonFilter && "
+            "Flag_BadPFMuonDzFilter && "
+            "Flag_hfNoisyHitsFilter &&"
+            "Flag_eeBadScFilter && "
+            "Flag_ecalBadCalibFilter)) || "
+        "(isRun2 && (Flag_goodVertices && "
+            "(!isData || Flag_globalSuperTightHalo2016Filter) && "
+            "Flag_HBHENoiseFilter && "
+            "Flag_HBHENoiseIsoFilter && "
+            "Flag_EcalDeadCellTriggerPrimitiveFilter && "
+            "Flag_BadPFMuonFilter &&"
+            "Flag_BadPFMuonDzFilter && "
+            "Flag_eeBadScFilter && "
+            "(!(is2017 || is2018) || Flag_ecalBadCalibFilter)))"
+        );
+}
+
 RNode TriggerSelections(RNode df_, std::string trigger_logic_string) {
 
     // Add default values to the df for all triggers that show up in the trigger_logic_string
@@ -123,7 +144,8 @@ RNode AK8JetsSelection(RNode df_)
 
 RNode runPreselection(RNode df_, std::string channel, bool noCut)
 {
-    auto df = LeptonSelections(df_);
+    auto df = METFilters(df_);
+    df = LeptonSelections(df_);
     df = AK4JetsSelection(df);
     df = AK8JetsSelection(df);
     df = df.Define("jet_minDrFromAnyGoodFatJet", dRfromClosestJet, {"jet_eta", "jet_phi", "fatjet_eta", "fatjet_phi"})

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -144,14 +144,17 @@ RNode AK8JetsSelection(RNode df_)
 
 RNode runPreselection(RNode df_, std::string channel, bool noCut)
 {
+
+    Cutflow::Add(df_, "All events");
+    
     auto df = METFilters(df_);
-    df = LeptonSelections(df_);
+    df = LeptonSelections(df);
     df = AK4JetsSelection(df);
     df = AK8JetsSelection(df);
     df = df.Define("jet_minDrFromAnyGoodFatJet", dRfromClosestJet, {"jet_eta", "jet_phi", "fatjet_eta", "fatjet_phi"})
             .Define("jet_passFatJetOverlapRemoval", "jet_minDrFromAnyGoodFatJet>0.8");
 
-    Cutflow::Add(df_, "All events");
+    Cutflow::Add(df, "C0: MET filters");
 
     if (noCut) return df;
 

--- a/preselection/src/selections.h
+++ b/preselection/src/selections.h
@@ -20,6 +20,8 @@ RNode AK4JetsSelection(RNode df);
 
 RNode runPreselection(RNode df_, std::string channel, bool noCut);
 
+RNode METFilters(RNode df_);
+
 // Trigger selections
 RNode TriggerSelections(RNode df_, std::string trigger_logic_string);
 // Trigger logic sring, paste this in from the output of the script for building this logic


### PR DESCRIPTION
- the code breaks when running on 22/23 data since the btagging WPs are not defined.
- using 2024 WPs for now (since the ParT training used for v15 is the same) but probably needs to be double checked.
- officially no WPs exist for 22/23 v15.
- also remove metPhi corrections for 22/23 for now.