### PR TITLE
Lep ID updates

### DIFF
--- a/preselection/run_rdf.py
+++ b/preselection/run_rdf.py
@@ -122,9 +122,7 @@ def main():
             # Assume we want signal, data, and bkg
             run_base = f"etc/input_sample_jsons/run{args.run}"
             jsons = [
-                f"{run_base}/sig_c2v1p0_c3_1p0/all_events/",
-                f"{run_base}/sig_c2v1p5_c3_1p0/all_events/",
-                f"{run_base}/sig_c2v1p0_c3_10p0/all_events/",
+                f"{run_base}/sig/all_events/",
                 f"{run_base}/bkg/{ANA_CHANNELS[chan_name]}",
                 f"{run_base}/data/{ANA_CHANNELS[chan_name]}",
             ]

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -91,10 +91,62 @@ RNode MuonSelections(RNode df_)
     return applyObjectMaskNewAffix(df, "_tightMuons", "Muon", "muon");
 }
 
+
+// Run 2 muon selection
+RNode ElectronSelectionsR2(RNode df_)
+{
+    auto df = df_.Define("Electron_SC_eta", "Electron_eta + Electron_deltaEtaSC");
+
+    df = df.Define(
+        "_looseElectrons",
+        "Electron_pt > 10 &&"
+        "abs(Electron_SC_eta) < 2.5 && "
+        "((abs(Electron_SC_eta) <= 1.479 && abs(Electron_dxy) <= 0.05 && abs(Electron_dz) < 0.1) || ((abs(Electron_SC_eta) > 1.479) && abs(Electron_dxy) <= 0.1 && abs(Electron_dz) < 0.2)) && "
+        "Electron_cutBased >= 1"
+    );
+    df = df.Define(
+        "_tightElectrons",
+        "_looseElectrons &&"
+        "Electron_cutBased >= 3"
+    );
+    df = df.Define("nElectron_Loose", "nElectron == 0 ? 0 : Sum(_looseElectrons)");
+    df = df.Define("nElectron_Tight", "nElectron_Loose == 0 ? 0 : Sum(_tightElectrons)");
+    df = df.Define("vvhTightLepMaskElectron", "_tightElectrons");
+    return applyObjectMaskNewAffix(df, "_tightElectrons", "Electron", "electron");
+}
+
+// Run 2 muon selections
+RNode MuonSelectionsR2(RNode df_)
+{
+    auto df = df_.Define(
+        "_looseMuons",
+        "Muon_pt > 10 && "
+        "Muon_pfIsoId >= 2 && "
+        "abs(Muon_eta) < 2.4 && "
+        "abs(Muon_dxy) < 0.2 && "
+        "abs(Muon_dz) < 0.5 && "
+        "abs(Muon_sip3d) < 8 && "
+        "Muon_looseId"
+    );
+    df = df.Define(
+        "_tightMuons",
+        "_looseMuons && "
+        "Muon_pt > 10 && "
+        "Muon_pfIsoId > 4 && "
+        "Muon_mediumId"
+    );
+    df = df.Define("nMuon_Loose", "nMuon == 0 ? 0 : Sum(_looseMuons)");
+    df = df.Define("nMuon_Tight", "nMuon_Loose == 0 ? 0 : Sum(_tightMuons)");
+    df = df.Define("vvhTightLepMaskMuon", "_tightMuons");
+    return applyObjectMaskNewAffix(df, "_tightMuons", "Muon", "muon");
+}
+
 RNode LeptonSelections(RNode df_)
 {
-    auto df = ElectronSelections(df_);
-    df = MuonSelections(df);
+    auto df = ElectronSelectionsR2(df_);
+    df = MuonSelectionsR2(df);
+    //auto df = ElectronSelections(df_);
+    //df = MuonSelections(df);
     return df.Define("lepton_pt", "Concatenate(electron_pt, muon_pt)")
             .Define("_leptonSorted", "Argsort(-lepton_pt)")
             .Redefine("lepton_pt", "Take(lepton_pt, _leptonSorted)")

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -107,7 +107,7 @@ RNode ElectronSelectionsR2(RNode df_)
     df = df.Define(
         "_tightElectrons",
         "_looseElectrons &&"
-        "Electron_cutBased >= 3"
+        "Electron_cutBased >= 2"
     );
     df = df.Define("nElectron_Loose", "nElectron == 0 ? 0 : Sum(_looseElectrons)");
     df = df.Define("nElectron_Tight", "nElectron_Loose == 0 ? 0 : Sum(_tightElectrons)");
@@ -132,7 +132,7 @@ RNode MuonSelectionsR2(RNode df_)
         "_tightMuons",
         "_looseMuons && "
         "Muon_pt > 10 && "
-        "Muon_pfIsoId > 4 && "
+        "Muon_pfIsoId >= 3 && "
         "Muon_mediumId"
     );
     df = df.Define("nMuon_Loose", "nMuon == 0 ? 0 : Sum(_looseMuons)");

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -50,27 +50,42 @@ RNode ElectronSelections(RNode df_)
 {
     auto df = df_.Define("Electron_SC_eta", "Electron_eta + Electron_deltaEtaSC");
 
+    // Veto selection
     df = df.Define(
-        "_looseElectrons",
+        "_vetoElectrons",
         "Electron_pt > 10 &&"
         "abs(Electron_SC_eta) < 2.5 && "
         "((abs(Electron_SC_eta) <= 1.479 && abs(Electron_dxy) <= 0.05 && abs(Electron_dz) < 0.1) || ((abs(Electron_SC_eta) > 1.479) && abs(Electron_dxy) <= 0.1 && abs(Electron_dz) < 0.2)) && "
         "Electron_cutBased >= 1"
     );
+
+    // Loose selection
     df = df.Define(
-        "_tightElectrons",
-        "_looseElectrons &&"
+        "_looseElectrons",
+        "_vetoElectrons &&"
         "Electron_cutBased >= 2"
     );
-    df = df.Define("nElectron_Loose", "nElectron == 0 ? 0 : Sum(_looseElectrons)");
-    df = df.Define("nElectron_Tight", "nElectron_Loose == 0 ? 0 : Sum(_tightElectrons)");
-    df = df.Define("vvhTightLepMaskElectron", "_tightElectrons");
-    return applyObjectMaskNewAffix(df, "_tightElectrons", "Electron", "electron");
+
+    // Define the counts of each
+    df = df.Define("nElectron_Veto", "nElectron == 0 ? 0 : Sum(_vetoElectrons)");
+    df = df.Define("nElectron_Loose", "nElectron_Veto == 0 ? 0 : Sum(_looseElectrons)");
+
+    // We will write out the electron object
+    df = applyObjectMaskNewAffix(df, "_vetoElectrons", "Electron", "electron");
+
+    // Append the masks to electron object
+    df = df.Define("electron_isLoose",  "electron_cutBased >=2");
+    df = df.Define("electron_isMedium", "electron_cutBased >=3");
+    df = df.Define("electron_isTight",  "electron_cutBased >=4");
+
+    return df;
 }
 
 // Muon selections
 RNode MuonSelections(RNode df_)
 {
+
+    // Loose selection
     auto df = df_.Define(
         "_looseMuons",
         "Muon_pt > 10 && "
@@ -81,17 +96,28 @@ RNode MuonSelections(RNode df_)
         "abs(Muon_sip3d) < 8 && "
         "Muon_looseId"
     );
+
+    // Medium selection
     df = df.Define(
-        "_tightMuons",
+        "_mediumMuons",
         "_looseMuons && "
-        "Muon_pt > 10 && "
         "Muon_pfIsoId >= 3 && "
         "Muon_mediumId"
     );
+
+    // Define the counts of each
     df = df.Define("nMuon_Loose", "nMuon == 0 ? 0 : Sum(_looseMuons)");
-    df = df.Define("nMuon_Tight", "nMuon_Loose == 0 ? 0 : Sum(_tightMuons)");
-    df = df.Define("vvhTightLepMaskMuon", "_tightMuons");
-    return applyObjectMaskNewAffix(df, "_tightMuons", "Muon", "muon");
+    df = df.Define("nMuon_Medium", "nMuon_Loose == 0 ? 0 : Sum(_mediumMuons)");
+
+    // We will write out the muon object
+    df = applyObjectMaskNewAffix(df, "_looseMuons", "Muon", "muon");
+
+    // Append the masks to electron object
+    df = df.Define("muon_isMedium",    "Muon_mediumId && (Muon_pfIsoId >=3)");
+    df = df.Define("muon_isTight",     "Muon_mediumId && (Muon_pfIsoId >=4)");
+    df = df.Define("muon_isVeryTight", "Muon_mediumId && (Muon_pfIsoId >=5)");
+
+    return df;
 }
 
 RNode LeptonSelections(RNode df_)

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -44,56 +44,9 @@ RNode TriggerSelections(RNode df_, std::string trigger_logic_string) {
     return df_.Filter(trigger_condition, "C1: Trigger Selection");
 }
 
+
+// Ele selection
 RNode ElectronSelections(RNode df_)
-{
-    auto df = df_.Define("Electron_SC_eta", "Electron_eta + Electron_deltaEtaSC")
-                  .Define("_looseElectrons", "Electron_pt > 7 &&"
-                                            "abs(Electron_SC_eta) < 2.5 && "
-                                            "((abs(Electron_SC_eta) <= 1.479 && abs(Electron_dxy) <= 0.05 && abs(Electron_dz) < 0.1) || (abs(Electron_dxy) <= 0.1 && abs(Electron_dz) < 0.2)) && "
-                                            "abs(Electron_sip3d) < 8 && "
-                                            "Electron_cutBased >= 2 && "
-                                            "Electron_pfRelIso03_all < 0.4 && "
-                                            "Electron_lostHits <= 1")
-                  .Define("_tightElectrons", "_looseElectrons &&"
-                                             "Electron_pt > 10 && "
-                                             "Electron_cutBased >= 4 && "
-                                             "Electron_pfRelIso03_all < 0.15 && "
-                                             "Electron_hoe < 0.1 && "
-                                             "Electron_eInvMinusPInv > -0.04 && "
-                                             "((abs(Electron_SC_eta) <= 1.479 && Electron_sieie < 0.011) || Electron_sieie <= 0.030) && "
-                                             "Electron_convVeto == true && "
-                                             "Electron_tightCharge == 2 && "
-                                             "Electron_lostHits == 0")
-                  .Define("nElectron_Loose", "nElectron == 0 ? 0 : Sum(_looseElectrons)")
-                  .Define("nElectron_Tight", "nElectron_Loose == 0 ? 0 : Sum(_tightElectrons)")
-                  .Define("vvhTightLepMaskElectron", "_tightElectrons");
-    return applyObjectMaskNewAffix(df, "_tightElectrons", "Electron", "electron");
-}
-
-RNode MuonSelections(RNode df_)
-{
-    auto df = df_.Define("_looseMuons", "Muon_pt > 5 && "
-                                        "Muon_pfIsoId >= 2 && "
-                                        "abs(Muon_eta) < 2.4 && "
-                                        "abs(Muon_dxy) < 0.2 && "
-                                        "abs(Muon_dz) < 0.5 && "
-                                        "abs(Muon_sip3d) < 8 && "
-                                        "Muon_looseId")
-                  .Define("_tightMuons", "_looseMuons && "
-                                         "Muon_pt > 10 && "
-                                         "Muon_pfIsoId > 4 && "
-                                         "Muon_tightCharge == 2 && "
-                                         "Muon_highPurity && "
-                                         "Muon_tightId")
-                  .Define("nMuon_Loose", "nMuon == 0 ? 0 : Sum(_looseMuons)")
-                  .Define("nMuon_Tight", "nMuon_Loose == 0 ? 0 : Sum(_tightMuons)")
-                  .Define("vvhTightLepMaskMuon", "_tightMuons");
-    return applyObjectMaskNewAffix(df, "_tightMuons", "Muon", "muon");
-}
-
-
-// Run 2 muon selection
-RNode ElectronSelectionsR2(RNode df_)
 {
     auto df = df_.Define("Electron_SC_eta", "Electron_eta + Electron_deltaEtaSC");
 
@@ -115,8 +68,8 @@ RNode ElectronSelectionsR2(RNode df_)
     return applyObjectMaskNewAffix(df, "_tightElectrons", "Electron", "electron");
 }
 
-// Run 2 muon selections
-RNode MuonSelectionsR2(RNode df_)
+// Muon selections
+RNode MuonSelections(RNode df_)
 {
     auto df = df_.Define(
         "_looseMuons",
@@ -143,10 +96,8 @@ RNode MuonSelectionsR2(RNode df_)
 
 RNode LeptonSelections(RNode df_)
 {
-    auto df = ElectronSelectionsR2(df_);
-    df = MuonSelectionsR2(df);
-    //auto df = ElectronSelections(df_);
-    //df = MuonSelections(df);
+    auto df = ElectronSelections(df_);
+    df = MuonSelections(df);
     return df.Define("lepton_pt", "Concatenate(electron_pt, muon_pt)")
             .Define("_leptonSorted", "Argsort(-lepton_pt)")
             .Redefine("lepton_pt", "Take(lepton_pt, _leptonSorted)")

--- a/preselection/src/selections.h
+++ b/preselection/src/selections.h
@@ -13,6 +13,8 @@
 
 using RNode = ROOT::RDF::RNode;
 
+RNode ElectronSelectionsR2(RNode df);
+RNode MuonSelectionsR2(RNode df);
 RNode ElectronSelections(RNode df);
 RNode MuonSelections(RNode df);
 RNode AK8JetsSelection(RNode df);

--- a/preselection/src/selections.h
+++ b/preselection/src/selections.h
@@ -13,8 +13,6 @@
 
 using RNode = ROOT::RDF::RNode;
 
-RNode ElectronSelectionsR2(RNode df);
-RNode MuonSelectionsR2(RNode df);
 RNode ElectronSelections(RNode df);
 RNode MuonSelections(RNode df);
 RNode AK8JetsSelection(RNode df);


### PR DESCRIPTION
This PR updates the lep IDs. 
* For electrons, we count with loose leptons, and write out veto leptons. 
* For Muons, we count with loose (`looseId` and `pfIsoId >= 2`) and we also write these out. We also remove some requirements that are non standard for muons (e.g., tight charge).

For both electrons and muons, we write out a flag like `isMedium` etc in case tighter selections would like to be used at analysis level. 