### PR TITLE
Proposed changes to 2lep_1FJ definition for channel splitting

### DIFF
--- a/preselection/run_rdf.py
+++ b/preselection/run_rdf.py
@@ -15,7 +15,8 @@ ANA_CHANNELS = {
         "1lep_1FJ"     : "1lep_1FJ",
         "1lep_2FJ"     : "1lep_1FJ",
         #"2lepSS"       : "2lepSS", # DNE yet
-        "2lep_1FJ"     : "2lep_1FJ", # Analysis channel shared between SF and OF
+        "2lep_1FJ_onZ" : "2lep_1FJ",
+        "2lep_FJ_offZ" : "2lep_1FJ",
         "2lep_2FJ"     : "2lep_2FJ",
         "3lep"         : "3lep",
         "4lep"         : "4lep",

--- a/preselection/run_rdf.py
+++ b/preselection/run_rdf.py
@@ -6,20 +6,20 @@ import subprocess
 
 # The known analysis channels (key) and which skim they use (value)
 ANA_CHANNELS = {
-        "0lep_0FJ"     : "0lep_0FJ",
-        "0lep_1FJ"     : "0lep_1FJ",
-        "0lep_1FJ_met" : "0lep_1FJ",
-        "0lep_2FJ"     : "0lep_2FJ",
-        "0lep_2FJ_met" : "0lep_2FJ",
-        "0lep_3FJ"     : "0lep_3FJ",
-        "1lep_1FJ"     : "1lep_1FJ",
-        "1lep_2FJ"     : "1lep_1FJ",
+        "0lep_0FJ"      : "0lep_0FJ",
+        "0lep_1FJ"      : "0lep_1FJ",
+        "0lep_1FJ_met"  : "0lep_1FJ",
+        "0lep_2FJ"      : "0lep_2FJ",
+        "0lep_2FJ_met"  : "0lep_2FJ",
+        "0lep_3FJ"      : "0lep_3FJ",
+        "1lep_1FJ"      : "1lep_1FJ",
+        "1lep_2FJ"      : "1lep_1FJ",
         #"2lepSS"       : "2lepSS", # DNE yet
-        "2lep_1FJ_onZ" : "2lep_1FJ",
-        "2lep_FJ_offZ" : "2lep_1FJ",
-        "2lep_2FJ"     : "2lep_2FJ",
-        "3lep"         : "3lep",
-        "4lep"         : "4lep",
+        "2lep_1FJ_onZ"  : "2lep_1FJ",
+        "2lep_1FJ_offZ" : "2lep_1FJ",
+        "2lep_2FJ"      : "2lep_2FJ",
+        "3lep"          : "3lep",
+        "4lep"          : "4lep",
 }
 
 # Merge the input jsons into one dictionary

--- a/preselection/src/main.cpp
+++ b/preselection/src/main.cpp
@@ -79,7 +79,8 @@ int main(int argc, char** argv) {
         "0lep_3FJ",
         "1lep_1FJ",
         "1lep_2FJ",
-        "2lep_1FJ", // Currently shared between SF and OF
+        "2lep_1FJ_onZ",
+	"2lep_1FJ_offZ",
         "2lepSS",
         "2lep_2FJ",
         "3lep",

--- a/preselection/src/main.cpp
+++ b/preselection/src/main.cpp
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
         "1lep_1FJ",
         "1lep_2FJ",
         "2lep_1FJ_onZ",
-	"2lep_1FJ_offZ",
+        "2lep_1FJ_offZ",
         "2lepSS",
         "2lep_2FJ",
         "3lep",

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -335,14 +335,14 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
 
         df = df.Filter( //Require exactly 2 electrons or 2 muons
             "(!(nMuon_Loose == 2) != !(nElectron_Loose == 2)) &&" 
-	    "((nMuon_Loose + nElectron_Loose) == 2) &&"
+	        "((nMuon_Loose + nElectron_Loose) == 2) &&"
             "(nFatJets == 1)",
             "C2: 2lep_1FJ_onZ");
-	df = df.Filter("(ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass)[0] > 81 ) && (ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass)[0]  < 101) ", "C3: invariant mass selection");
-	df = df.Filter("lepton_charge[0] * lepton_charge[1] < 0", "C4: Opposite Sign");
+	    df = df.Filter("(ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass)[0] > 81 ) && (ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass)[0]  < 101) ", "C3: invariant mass selection");
+	    df = df.Filter("lepton_charge[0] * lepton_charge[1] < 0", "C4: Opposite Sign");
     }
 
-    else if (channel == "2lep_1FJ_offZ"){
+     else if (channel == "2lep_1FJ_offZ"){
 
       df = TriggerSelections(df,trigger_logic_string_multilep);
       Cutflow::Add(df, "C1: Trigger selection");
@@ -352,8 +352,8 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
 	   "C2: 2lep_1FJ_offZ");
       df = df.Filter(//Apply dilepton mass cut only to 2mu/2e channels
 	   "((nMuon_Loose == 1) && (nElectron_Loose == 1)) ||"
-           "(((!(nMuon_Loose == 2) != !(nElectron_Loose == 2)) && ((ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass)[0] < 81) || (ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass)[0] > 101)))",
-           "C3: invariant mass selection");
+        "(((!(nMuon_Loose == 2) != !(nElectron_Loose == 2)) && ((ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass)[0] < 81) || (ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass)[0] > 101)))",
+        "C3: invariant mass selection");
       df = df.Filter("lepton_charge[0] * lepton_charge[1] < 0", "C4: Opposite Sign");
 
     }

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -130,7 +130,8 @@ RNode LeptonSelections(RNode df_)
             .Define("lepton_eta", "Take(Concatenate(electron_eta, muon_eta), _leptonSorted)")
             .Define("lepton_phi", "Take(Concatenate(electron_phi, muon_phi), _leptonSorted)")
             .Define("lepton_mass", "Take(Concatenate(electron_mass, muon_mass), _leptonSorted)")
-            .Define("lepton_charge", "Take(Concatenate(electron_charge, muon_charge), _leptonSorted)");
+            .Define("lepton_charge", "Take(Concatenate(electron_charge, muon_charge), _leptonSorted)")
+            .Define("lepton_invMass", "ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass)");
 }
 
 RNode AK4JetsSelection(RNode df_)
@@ -335,10 +336,10 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
 
         df = df.Filter( //Require exactly 2 electrons or 2 muons
             "(!(nMuon_Loose == 2) != !(nElectron_Loose == 2)) &&" 
-	    "((nMuon_Loose + nElectron_Loose) == 2) &&"
+	        "((nMuon_Loose + nElectron_Loose) == 2) &&"
             "(nFatJets == 1)",
             "C2: 2lep_1FJ_onZ");
-	    df = df.Filter("(ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass) > 81 ) && (ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass)  < 101) ", "C3: invariant mass selection");
+	    df = df.Filter("(lepton_invMass > 81) && (lepton_invMass < 101) ", "C3: invariant mass selection");
 	    df = df.Filter("lepton_charge[0] * lepton_charge[1] < 0", "C4: Opposite Sign");
     }
 
@@ -352,7 +353,7 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
 	   "C2: 2lep_1FJ_offZ");
       df = df.Filter(//Apply dilepton mass cut only to 2mu/2e channels
 	   "((nMuon_Loose == 1) && (nElectron_Loose == 1)) || "
-	   "((!(nMuon_Loose == 2) != !(nElectron_Loose == 2)) && ((ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass) < 81) || (ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass) > 101)))",
+	   "((!(nMuon_Loose == 2) != !(nElectron_Loose == 2)) && ((lepton_invMass < 81) || (lepton_invMass > 101)))",
 	   "C3: invariant mass selection");
       df = df.Filter("lepton_charge[0] * lepton_charge[1] < 0", "C4: Opposite Sign");
 

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -341,6 +341,7 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
             //TODO implement a same sign requirement
             "C2: 2lepSS"
         );
+	df = df.Filter("lepton_charge[0] * lepton_charge[1] > 0", "C4: Same Sign");
     }
 
     // 2lep_1FJ (currently shared between OF and SF)
@@ -356,6 +357,7 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
             "C2: 2lep_1FJ_onZ");
 	df = diLeptonMass(df);
 	df = df.Filter("(dilepton_mass > 81) && (dilepton_mass < 101) ", "C3: invariant mass selection");
+	df = df.Filter("lepton_charge[0] * lepton_charge[1] < 0", "C4: Opposite Sign");
     }
 
     else if (channel == "2lep_1FJ_offZ"){
@@ -371,6 +373,7 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
 	   "((nMuon_Loose == 1) && (nElectron_Loose == 1)) ||"
            "(((!(nMuon_Loose == 2) != !(nElectron_Loose == 2)) && ((dilepton_mass < 81) || (dilepton_mass > 101)))",
            "C3: invariant mass selection");
+      df = df.Filter("lepton_charge[0] * lepton_charge[1] < 0", "C4: Opposite Sign");
 
     }
     // 2lep_2FJ

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -170,24 +170,7 @@ RNode AK8JetsSelection(RNode df_)
 
     return df;
 }
-RNode diLeptonMass(RNode df_)
-{
-  auto df = df_.Define(
-		       "dilepton_mass",
-		       [](const RVec<float>& pt,
-			  const RVec<float>& eta,
-			  const RVec<float>& phi,
-			  const RVec<float>& mass) {
-			 // assume at least two leptons in the event
-			 ROOT::Math::PtEtaPhiMVector l1(pt[0], eta[0], phi[0], mass[0]);
-			 ROOT::Math::PtEtaPhiMVector l2(pt[1], eta[1], phi[1], mass[1]);
-			 
-			 return (l1 + l2).M();
-		       },
-		       {"lepton_pt", "lepton_eta", "lepton_phi", "lepton_mass"}
-		       );
-  return df;
-}
+
 
 RNode runPreselection(RNode df_, std::string channel, bool noCut)
 {
@@ -355,8 +338,7 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
 	    "((nMuon_Loose + nElectron_Loose) == 2) &&"
             "(nFatJets == 1)",
             "C2: 2lep_1FJ_onZ");
-	df = diLeptonMass(df);
-	df = df.Filter("(dilepton_mass > 81) && (dilepton_mass < 101) ", "C3: invariant mass selection");
+	df = df.Filter("(ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass)[0] > 81 ) && (ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass)[0]  < 101) ", "C3: invariant mass selection");
 	df = df.Filter("lepton_charge[0] * lepton_charge[1] < 0", "C4: Opposite Sign");
     }
 
@@ -364,14 +346,13 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
 
       df = TriggerSelections(df,trigger_logic_string_multilep);
       Cutflow::Add(df, "C1: Trigger selection");
-      df = diLeptonMass(df);
       df = df.Filter( //Require either e+mu or 2mu/2e
 	   "((nMuon_Loose == 1) && (nElectron_Loose == 1)) ||"
 	   "(((!(nMuon_Loose == 2) != !(nElectron_Loose == 2)))",
 	   "C2: 2lep_1FJ_offZ");
       df = df.Filter(//Apply dilepton mass cut only to 2mu/2e channels
 	   "((nMuon_Loose == 1) && (nElectron_Loose == 1)) ||"
-           "(((!(nMuon_Loose == 2) != !(nElectron_Loose == 2)) && ((dilepton_mass < 81) || (dilepton_mass > 101)))",
+           "(((!(nMuon_Loose == 2) != !(nElectron_Loose == 2)) && ((ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass)[0] < 81) || (ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass)[0] > 101)))",
            "C3: invariant mass selection");
       df = df.Filter("lepton_charge[0] * lepton_charge[1] < 0", "C4: Opposite Sign");
 

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -335,25 +335,25 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
 
         df = df.Filter( //Require exactly 2 electrons or 2 muons
             "(!(nMuon_Loose == 2) != !(nElectron_Loose == 2)) &&" 
-	        "((nMuon_Loose + nElectron_Loose) == 2) &&"
+	    "((nMuon_Loose + nElectron_Loose) == 2) &&"
             "(nFatJets == 1)",
             "C2: 2lep_1FJ_onZ");
-	    df = df.Filter("(ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass)[0] > 81 ) && (ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass)[0]  < 101) ", "C3: invariant mass selection");
+	    df = df.Filter("(ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass) > 81 ) && (ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass)  < 101) ", "C3: invariant mass selection");
 	    df = df.Filter("lepton_charge[0] * lepton_charge[1] < 0", "C4: Opposite Sign");
     }
 
-     else if (channel == "2lep_1FJ_offZ"){
+    else if (channel == "2lep_1FJ_offZ"){
 
       df = TriggerSelections(df,trigger_logic_string_multilep);
       Cutflow::Add(df, "C1: Trigger selection");
       df = df.Filter( //Require either e+mu or 2mu/2e
-	   "((nMuon_Loose == 1) && (nElectron_Loose == 1)) ||"
-	   "(((!(nMuon_Loose == 2) != !(nElectron_Loose == 2)))",
+	   "((nMuon_Loose == 1) && (nElectron_Loose == 1)) || "
+	   "((!(nMuon_Loose == 2) != !(nElectron_Loose == 2)))",
 	   "C2: 2lep_1FJ_offZ");
       df = df.Filter(//Apply dilepton mass cut only to 2mu/2e channels
-	   "((nMuon_Loose == 1) && (nElectron_Loose == 1)) ||"
-        "(((!(nMuon_Loose == 2) != !(nElectron_Loose == 2)) && ((ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass)[0] < 81) || (ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass)[0] > 101)))",
-        "C3: invariant mass selection");
+	   "((nMuon_Loose == 1) && (nElectron_Loose == 1)) || "
+	   "((!(nMuon_Loose == 2) != !(nElectron_Loose == 2)) && ((ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass) < 81) || (ROOT::VecOps::InvariantMass(lepton_pt,lepton_eta,lepton_phi,lepton_mass) > 101)))",
+	   "C3: invariant mass selection");
       df = df.Filter("lepton_charge[0] * lepton_charge[1] < 0", "C4: Opposite Sign");
 
     }

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -170,6 +170,24 @@ RNode AK8JetsSelection(RNode df_)
 
     return df;
 }
+RNode diLeptonMass(RNode df_)
+{
+  auto df = df_.Define(
+		       "dilepton_mass",
+		       [](const RVec<float>& pt,
+			  const RVec<float>& eta,
+			  const RVec<float>& phi,
+			  const RVec<float>& mass) {
+			 // assume at least two leptons in the event
+			 ROOT::Math::PtEtaPhiMVector l1(pt[0], eta[0], phi[0], mass[0]);
+			 ROOT::Math::PtEtaPhiMVector l2(pt[1], eta[1], phi[1], mass[1]);
+			 
+			 return (l1 + l2).M();
+		       },
+		       {"lepton_pt", "lepton_eta", "lepton_phi", "lepton_mass"}
+		       );
+  return df;
+}
 
 RNode runPreselection(RNode df_, std::string channel, bool noCut)
 {
@@ -326,18 +344,35 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
     }
 
     // 2lep_1FJ (currently shared between OF and SF)
-    else if (channel == "2lep_1FJ"){
+    else if (channel == "2lep_1FJ_onZ"){
 
         df = TriggerSelections(df,trigger_logic_string_multilep);
         Cutflow::Add(df, "C1: Trigger selection");
 
-        df = df.Filter(
-            "((nMuon_Loose + nElectron_Loose) == 2) &&"
+        df = df.Filter( //Require exactly 2 electrons or 2 muons
+            "(!(nMuon_Loose == 2) != !(nElectron_Loose == 2)) &&" 
+	    "((nMuon_Loose + nElectron_Loose) == 2) &&"
             "(nFatJets == 1)",
-            "C2: 2lep_1FJ"
-        );
+            "C2: 2lep_1FJ_onZ");
+	df = diLeptonMass(df);
+	df = df.Filter("(dilepton_mass > 81) && (dilepton_mass < 101) ", "C3: invariant mass selection");
     }
 
+    else if (channel == "2lep_1FJ_offZ"){
+
+      df = TriggerSelections(df,trigger_logic_string_multilep);
+      Cutflow::Add(df, "C1: Trigger selection");
+      df = diLeptonMass(df);
+      df = df.Filter( //Require either e+mu or 2mu/2e
+	   "((nMuon_Loose == 1) && (nElectron_Loose == 1)) ||"
+	   "(((!(nMuon_Loose == 2) != !(nElectron_Loose == 2)))",
+	   "C2: 2lep_1FJ_offZ");
+      df = df.Filter(//Apply dilepton mass cut only to 2mu/2e channels
+	   "((nMuon_Loose == 1) && (nElectron_Loose == 1)) ||"
+           "(((!(nMuon_Loose == 2) != !(nElectron_Loose == 2)) && ((dilepton_mass < 81) || (dilepton_mass > 101)))",
+           "C3: invariant mass selection");
+
+    }
     // 2lep_2FJ
     else if (channel == "2lep_2FJ"){
 

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -322,13 +322,12 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
 
         df = df.Filter(
             "((nMuon_Loose + nElectron_Loose) == 2)",
-            //TODO implement a same sign requirement
             "C2: 2lepSS"
         );
-	df = df.Filter("lepton_charge[0] * lepton_charge[1] > 0", "C4: Same Sign");
+	    df = df.Filter("lepton_charge[0] * lepton_charge[1] > 0", "C4: Same Sign");
     }
 
-    // 2lep_1FJ (currently shared between OF and SF)
+    // 2lep_1FJ_onZ
     else if (channel == "2lep_1FJ_onZ"){
 
         df = TriggerSelections(df,trigger_logic_string_multilep);
@@ -342,20 +341,21 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
 	    df = df.Filter("(lepton_invMass > 81) && (lepton_invMass < 101) ", "C3: invariant mass selection");
 	    df = df.Filter("lepton_charge[0] * lepton_charge[1] < 0", "C4: Opposite Sign");
     }
-
+    // 2lep_1FJ_offZ
     else if (channel == "2lep_1FJ_offZ"){
 
-      df = TriggerSelections(df,trigger_logic_string_multilep);
-      Cutflow::Add(df, "C1: Trigger selection");
-      df = df.Filter( //Require either e+mu or 2mu/2e
-	   "((nMuon_Loose == 1) && (nElectron_Loose == 1)) || "
-	   "((!(nMuon_Loose == 2) != !(nElectron_Loose == 2)))",
-	   "C2: 2lep_1FJ_offZ");
-      df = df.Filter(//Apply dilepton mass cut only to 2mu/2e channels
-	   "((nMuon_Loose == 1) && (nElectron_Loose == 1)) || "
-	   "((!(nMuon_Loose == 2) != !(nElectron_Loose == 2)) && ((lepton_invMass < 81) || (lepton_invMass > 101)))",
-	   "C3: invariant mass selection");
-      df = df.Filter("lepton_charge[0] * lepton_charge[1] < 0", "C4: Opposite Sign");
+        df = TriggerSelections(df,trigger_logic_string_multilep);
+        Cutflow::Add(df, "C1: Trigger selection");
+        df = df.Filter( //Require either e+mu or 2mu/2e
+	        "((nMuon_Loose == 1) && (nElectron_Loose == 1)) || "
+	        "((!(nMuon_Loose == 2) != !(nElectron_Loose == 2)))",
+	        "C2: 2lep_1FJ_offZ");
+      
+        df = df.Filter(//Apply dilepton mass cut only to 2mu/2e channels
+            "((nMuon_Loose == 1) && (nElectron_Loose == 1)) || "
+	        "((!(nMuon_Loose == 2) != !(nElectron_Loose == 2)) && ((lepton_invMass < 81) || (lepton_invMass > 101)))",
+	        "C3: invariant mass selection");
+        df = df.Filter("lepton_charge[0] * lepton_charge[1] < 0", "C4: Opposite Sign");
 
     }
     // 2lep_2FJ


### PR DESCRIPTION
This PR splits the current 2lep_1FJ channel into on-Z and off-Z channels, by implementing a cut on dilepton mass at the RDF step. It also defines dilepton_mass as an output variable for these channels. This only applies to SF dilepton channels; 1e+1mu is handled separately. 