### PR TITLE
ABCD updates

### DIFF
--- a/abcd/main.py
+++ b/abcd/main.py
@@ -5,6 +5,7 @@ import re
 import sys
 import csv
 import yaml
+import shutil
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from argparse import ArgumentParser
 from pathlib import Path
@@ -870,7 +871,7 @@ def main():
     # Copy scaler params to the versioned checkpoint directory so they stay with the model
     checkpoint_path = _latest_checkpoint_from_config(cfg, flavor=flavor)
     scaler_path_final = _inference_output_dir_from_checkpoint(checkpoint_path) / "scaler_params.json"
-    shutil.copy(str(scaler_path_tmp), str(scaler_path_final))
+    shutil.copy(str(scaler_path), str(scaler_path_final))
     logging.info("Copied scaler params to %s", scaler_path_final)
 
     logging.info("Running inference...")

--- a/abcd/main.py
+++ b/abcd/main.py
@@ -378,8 +378,8 @@ def make_dataloaders(data, training_features, constraint_var, batch_size):
         is_validation=True,
     )
 
-    return train_loader, val_loader
-
+    # Also return indices so callers can tag events by their split for later analysis
+    return train_loader, val_loader, train_idx, val_idx
 
 def save_tensorboard_plots(log_dir, output_dir):
     ea = EventAccumulator(str(log_dir))
@@ -596,6 +596,84 @@ def _batched_scores(model, features_tensor, batch_size, flavor, device):
     out_1 = np.concatenate(scores_1) if scores_1 else np.array([], dtype=np.float32)
     return out_0, out_1
 
+def _plot_abcd_plane(data, flavor, constraint_var, output_path, title_suffix=""):
+    def profile_overlay(ax, x, y, bins, xrange):
+        bin_edges = np.linspace(xrange[0], xrange[1], bins + 1)
+        bin_centers = 0.5 * (bin_edges[:-1] + bin_edges[1:])
+        means, errors = [], []
+        for lo, hi in zip(bin_edges[:-1], bin_edges[1:]):
+            mask = (x >= lo) & (x < hi)
+            vals = y[mask]
+            if len(vals) > 0:
+                means.append(np.mean(vals))
+                errors.append(np.std(vals) / np.sqrt(len(vals)))
+            else:
+                means.append(np.nan)
+                errors.append(np.nan)
+        means = np.array(means)
+        errors = np.array(errors)
+        ax.errorbar(bin_centers, means, yerr=errors, color='yellow',
+                    fmt='o', markersize=3, linewidth=1.5, label='Profile mean')
+        ax.legend(fontsize=9)
+
+    labels = np.asarray(data["label"])
+    signal = {k: np.asarray(v)[labels == 1] for k, v in data.items()}
+    background = {k: np.asarray(v)[labels == 0] for k, v in data.items()}
+
+    score_col = "dnn_score" if flavor == "single" else "dnn_0_score"
+
+    bins = [50, 50]
+    dnn_range = (0, 1)
+    constrain_var_range = (0, max(np.asarray(data[constraint_var])))
+
+    fig, axes = plt.subplots(1, 2, figsize=(14, 6))
+
+    h1 = axes[0].hist2d(background[score_col], background[constraint_var], bins=bins,
+                         range=[dnn_range, constrain_var_range], cmap='Blues',
+                         norm=matplotlib.colors.LogNorm())
+    plt.colorbar(h1[3], ax=axes[0], label='Counts')
+    axes[0].set_title('Background')
+    axes[0].set_xlabel('DNN Score')
+    axes[0].set_ylabel(constraint_var)
+    profile_overlay(axes[0], background[score_col], background[constraint_var], bins[0], dnn_range)
+
+    h2 = axes[1].hist2d(signal[score_col], signal[constraint_var], bins=bins,
+                         range=[dnn_range, constrain_var_range], cmap='Reds',
+                         norm=matplotlib.colors.LogNorm())
+    plt.colorbar(h2[3], ax=axes[1], label='Counts')
+    axes[1].set_title('Signal')
+    axes[1].set_xlabel('DNN Score')
+    axes[1].set_ylabel(constraint_var)
+    profile_overlay(axes[1], signal[score_col], signal[constraint_var], bins[0], dnn_range)
+
+    fig.suptitle(f'ABCD Plane{" - " + title_suffix if title_suffix else ""}')
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150)
+    plt.close()
+    logging.info("Saved ABCD plane plot to %s", output_path)
+
+
+def _plot_decorrelation_check(data, flavor, constraint_var, output_path, title_suffix=""):
+    score_col = "dnn_score" if flavor == "single" else "dnn_0_score"
+    labels = np.asarray(data["label"])
+    background = {k: np.asarray(v)[labels == 0] for k, v in data.items()}
+
+    score_bins = [0.0, 0.25, 0.5, 0.75, 1.0]
+
+    fig, ax = plt.subplots(figsize=(7, 6))
+    for i in range(len(score_bins) - 1):
+        mask = (background[score_col] >= score_bins[i]) & (background[score_col] < score_bins[i + 1])
+        ax.hist(background[constraint_var][mask], bins=50, density=True,
+                histtype='step', label=f'DNN score [{score_bins[i]}, {score_bins[i + 1]}]')
+
+    ax.set_xlabel(constraint_var)
+    ax.set_ylabel('Normalised counts')
+    ax.legend()
+    ax.set_title(f'{constraint_var} in DNN score slices (background){" - " + title_suffix if title_suffix else ""}')
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150)
+    plt.close()
+    logging.info("Saved decorrelation check plot to %s", output_path)
 
 def _plot_roc_curves(data, flavor, output_path):
     labels = np.asarray(data["label"])
@@ -731,7 +809,7 @@ def plot_permutation_importance(baseline_auc, importances, output_path):
     print(f"Saved {output_path}")
 
 
-def run_inference(args, cfg, flavor, sig_data, bkg_data, training_features, feature_transforms, constraint_var, derived_vars_cfg, is_data=False, inference_data=None):
+def run_inference(args, cfg, flavor, sig_data, bkg_data, training_features, feature_transforms, constraint_var, derived_vars_cfg, is_data=False, inference_data=None, train_idx=None, val_idx=None):
     logging.info("Starting inference steps...")
     checkpoint_path = Path(args.checkpoint) if args.checkpoint else _latest_checkpoint_from_config(cfg, flavor=flavor)
     logging.info("Using checkpoint: %s", checkpoint_path)
@@ -739,7 +817,7 @@ def run_inference(args, cfg, flavor, sig_data, bkg_data, training_features, feat
     if is_data:
         full_inference_data = inference_data
     else:
-        full_inference_data = _concat_sig_bkg(sig_data, bkg_data)
+        full_inference_data = _concat_sig_bkg(sig_data, bkg_data)  # NOTE: must remain signal-first to match ordering assumed by train_idx/val_idx
         
     full_inference_data = apply_derived_vars(full_inference_data, derived_vars_cfg)
 
@@ -771,6 +849,14 @@ def run_inference(args, cfg, flavor, sig_data, bkg_data, training_features, feat
         full_inference_data["dnn_0_score"] = score_0
         full_inference_data["dnn_1_score"] = score_1
 
+    # Tag each event with its split so plots can be made per-subset
+    n_events = _data_length(full_inference_data)
+    split_col = np.full(n_events, "unknown", dtype=object)
+    if train_idx is not None and val_idx is not None:
+        split_col[train_idx] = "train"
+        split_col[val_idx] = "val"
+    full_inference_data["split"] = split_col
+
     if is_data:
         default_out = _inference_output_dir_from_checkpoint(checkpoint_path) / f"predictions_{flavor}_data.csv"
     else:
@@ -790,6 +876,23 @@ def run_inference(args, cfg, flavor, sig_data, bkg_data, training_features, feat
         _plot_score_densities(full_inference_data, flavor=flavor, output_path=density_path)
         logging.info("Saved ROC plot to %s", roc_path)
         logging.info("Saved score density plot to %s", density_path)
+
+        # Make ABCD plane and decorrelation plots (for all events, for train only, and for val only)
+        plot_subsets = [("all", full_inference_data)]
+        if train_idx is not None and val_idx is not None:
+            train_mask = np.asarray(full_inference_data["split"]) == "train"
+            val_mask   = np.asarray(full_inference_data["split"]) == "val"
+            plot_subsets.append(("train", _apply_mask(full_inference_data, train_mask)))
+            plot_subsets.append(("val",   _apply_mask(full_inference_data, val_mask)))
+
+        for subset_name, subset_data in plot_subsets:
+            abcd_path = output_csv.with_name(f"{output_csv.stem}_abcd_plane_{subset_name}.png")
+            _plot_abcd_plane(subset_data, flavor=flavor, constraint_var=constraint_var,
+                             output_path=abcd_path, title_suffix=subset_name)
+
+            decorr_path = output_csv.with_name(f"{output_csv.stem}_decorrelation_check_{subset_name}.png")
+            _plot_decorrelation_check(subset_data, flavor=flavor, constraint_var=constraint_var,
+                                      output_path=decorr_path, title_suffix=subset_name)
 
         # Compute and save permutation importance to identify which features the model relies on most
         importance_path = output_csv.with_name(f"{output_csv.stem}_permutation_importance.png")
@@ -887,7 +990,7 @@ def main():
         )
 
         logging.info("Skipping training. Running inference on data only...")
-        run_inference(args, cfg, flavor, None, None, training_features, feature_transforms, constraint_var, derived_vars_cfg, is_data=True, inference_data=real_data)
+        run_inference(args, cfg, flavor, None, None, training_features, feature_transforms, constraint_var, derived_vars_cfg, is_data=True, inference_data=real_data, train_idx=None, val_idx=None)
         return
 
     logging.info("Loading signal data...")
@@ -930,11 +1033,11 @@ def main():
 
     if args.infer:
         logging.info("Skipping training. Running inference only...")
-        run_inference(args, cfg, flavor, raw_sig_data, raw_bkg_data, training_features, feature_transforms, constraint_var, derived_vars_cfg)
+        run_inference(args, cfg, flavor, raw_sig_data, raw_bkg_data, training_features, feature_transforms, constraint_var, derived_vars_cfg, train_idx=None, val_idx=None)
         return
 
     logging.info("Creating data loaders...")
-    train_loader, val_loader = make_dataloaders(
+    train_loader, val_loader, train_idx, val_idx = make_dataloaders(
         data=data,
         training_features=training_features,
         constraint_var=constraint_var,
@@ -974,15 +1077,20 @@ def main():
     )
 
     logging.info("Training finished.")
+    checkpoint_path = _latest_checkpoint_from_config(cfg, flavor=flavor)
+    version_dir = _inference_output_dir_from_checkpoint(checkpoint_path)
+
+    # Save a copy of the config used for this run to the versioned directory for reference
+    shutil.copy(args.config, version_dir / Path(args.config).name)
+    logging.info("Saved config to %s", version_dir / Path(args.config).name)
 
     # Copy scaler params to the versioned checkpoint directory so they stay with the model
-    checkpoint_path = _latest_checkpoint_from_config(cfg, flavor=flavor)
-    scaler_path_final = _inference_output_dir_from_checkpoint(checkpoint_path) / "scaler_params.json"
+    scaler_path_final = version_dir / "scaler_params.json"
     shutil.copy(str(scaler_path), str(scaler_path_final))
     logging.info("Copied scaler params to %s", scaler_path_final)
 
     logging.info("Running inference...")
-    run_inference(args, cfg, flavor, raw_sig_data, raw_bkg_data, training_features, feature_transforms, constraint_var, derived_vars_cfg)
+    run_inference(args, cfg, flavor, raw_sig_data, raw_bkg_data, training_features, feature_transforms, constraint_var, derived_vars_cfg, train_idx=train_idx, val_idx=val_idx)
     logging.info("Inference finished.")
 
 if __name__ == "__main__":

--- a/abcd/main.py
+++ b/abcd/main.py
@@ -547,6 +547,15 @@ def _latest_checkpoint_from_config(cfg, flavor) -> Path:
         raise FileNotFoundError(f"No .ckpt files found under {ckpt_dir}")
     return sorted(ckpts, key=lambda p: p.stat().st_mtime)[-1]
 
+def _all_checkpoints_from_config(cfg, flavor) -> list:
+    output_dir = Path(cfg.get("output", "simple_abcdisco_output"))
+    version_dir = _latest_version_dir(output_dir, flavor=flavor)
+    ckpt_dir = version_dir / "checkpoints"
+    ckpts = [p for p in ckpt_dir.glob("*.ckpt") if p.is_file()]
+    if not ckpts:
+        raise FileNotFoundError(f"No .ckpt files found under {ckpt_dir}")
+    return sorted(ckpts, key=lambda p: p.stat().st_mtime)
+
 
 def _inference_output_dir_from_checkpoint(checkpoint_path: Path) -> Path:
     if checkpoint_path.parent.name == "checkpoints":
@@ -597,23 +606,27 @@ def _batched_scores(model, features_tensor, batch_size, flavor, device):
     return out_0, out_1
 
 def _plot_abcd_plane(data, flavor, constraint_var, output_path, title_suffix=""):
-    def profile_overlay(ax, x, y, bins, xrange):
+    def profile_overlay(ax, x, y, bins, xrange, weights=None, color='yellow', label='Profile mean'):
         bin_edges = np.linspace(xrange[0], xrange[1], bins + 1)
         bin_centers = 0.5 * (bin_edges[:-1] + bin_edges[1:])
         means, errors = [], []
         for lo, hi in zip(bin_edges[:-1], bin_edges[1:]):
             mask = (x >= lo) & (x < hi)
             vals = y[mask]
+            w = weights[mask] if weights is not None else None
             if len(vals) > 0:
-                means.append(np.mean(vals))
-                errors.append(np.std(vals) / np.sqrt(len(vals)))
+                mean = np.average(vals, weights=w)
+                variance = np.average((vals - mean) ** 2, weights=w)
+                n_eff = (np.sum(w) ** 2 / np.sum(w ** 2)) if w is not None else len(vals)
+                errors.append(np.sqrt(variance / n_eff))
+                means.append(mean)
             else:
                 means.append(np.nan)
                 errors.append(np.nan)
         means = np.array(means)
         errors = np.array(errors)
-        ax.errorbar(bin_centers, means, yerr=errors, color='yellow',
-                    fmt='o', markersize=3, linewidth=1.5, label='Profile mean')
+        ax.errorbar(bin_centers, means, yerr=errors, color=color,
+                    fmt='o', markersize=3, linewidth=1.5, label=label)
         ax.legend(fontsize=9)
 
     labels = np.asarray(data["label"])
@@ -636,6 +649,9 @@ def _plot_abcd_plane(data, flavor, constraint_var, output_path, title_suffix="")
     axes[0].set_xlabel('DNN Score')
     axes[0].set_ylabel(constraint_var)
     profile_overlay(axes[0], background[score_col], background[constraint_var], bins[0], dnn_range)
+    profile_overlay(axes[0], background[score_col], background[constraint_var], bins[0], dnn_range,
+                    weights=background["weight"] if "weight" in background else None,
+                    color='orange', label='Profile mean (weighted)')
 
     h2 = axes[1].hist2d(signal[score_col], signal[constraint_var], bins=bins,
                          range=[dnn_range, constrain_var_range], cmap='Reds',
@@ -645,6 +661,9 @@ def _plot_abcd_plane(data, flavor, constraint_var, output_path, title_suffix="")
     axes[1].set_xlabel('DNN Score')
     axes[1].set_ylabel(constraint_var)
     profile_overlay(axes[1], signal[score_col], signal[constraint_var], bins[0], dnn_range)
+    profile_overlay(axes[1], signal[score_col], signal[constraint_var], bins[0], dnn_range,
+                    weights=signal["weight"] if "weight" in signal else None,
+                    color='orange', label='Profile mean (weighted)')
 
     fig.suptitle(f'ABCD Plane{" - " + title_suffix if title_suffix else ""}')
     plt.tight_layout()
@@ -860,7 +879,7 @@ def run_inference(args, cfg, flavor, sig_data, bkg_data, training_features, feat
     if is_data:
         default_out = _inference_output_dir_from_checkpoint(checkpoint_path) / f"predictions_{flavor}_data.csv"
     else:
-        default_out = _inference_output_dir_from_checkpoint(checkpoint_path) / f"predictions_{flavor}.csv"
+        default_out = _inference_output_dir_from_checkpoint(checkpoint_path) / f"predictions_{flavor}_{checkpoint_path.stem}.csv"
 
     output_csv = Path(args.output_csv) if args.output_csv else default_out
     output_csv.parent.mkdir(parents=True, exist_ok=True)
@@ -1090,7 +1109,11 @@ def main():
     logging.info("Copied scaler params to %s", scaler_path_final)
 
     logging.info("Running inference...")
-    run_inference(args, cfg, flavor, raw_sig_data, raw_bkg_data, training_features, feature_transforms, constraint_var, derived_vars_cfg, train_idx=train_idx, val_idx=val_idx)
+    all_checkpoints = _all_checkpoints_from_config(cfg, flavor=flavor)
+    for ckpt_path in all_checkpoints:
+        logging.info("Running inference for checkpoint: %s", ckpt_path)
+        args.checkpoint = str(ckpt_path)
+        run_inference(args, cfg, flavor, raw_sig_data, raw_bkg_data, training_features, feature_transforms, constraint_var, derived_vars_cfg, train_idx=train_idx, val_idx=val_idx)
     logging.info("Inference finished.")
 
 if __name__ == "__main__":

--- a/abcd/main.py
+++ b/abcd/main.py
@@ -287,6 +287,11 @@ def preprocess_data(data, training_features, feature_transforms, constraint_var,
             valid = positive
         if transform == "log":
             feat_arr[valid] = np.log(feat_arr[valid])
+        if valid.sum() == 0:
+            print(f"WARNING: feature '{feat}' has no valid samples, skipping scaler fit")
+            out[feat] = np.zeros_like(feat_arr, dtype=np.float64)
+            scaler_params[feat] = {"transform": transform, "min": 0.0, "max": 1.0}
+            continue
         out[feat], fmin, fmax = _safe_minmax_scale(feat_arr, valid)
         scaler_params[feat] = {"transform": transform, "min": fmin, "max": fmax}
     if constraint_var not in training_features:
@@ -296,8 +301,13 @@ def preprocess_data(data, training_features, feature_transforms, constraint_var,
         scaler_params[constraint_var] = {"transform": "none", "min": fmin, "max": fmax}
     if scaler_output_path is not None:
         import json
+        scaler_out = {
+            "_training_features": training_features,
+            "_constraint_var": constraint_var,
+        }
+        scaler_out.update(scaler_params)
         with open(scaler_output_path, "w") as f:
-            json.dump(scaler_params, f, indent=2)
+            json.dump(scaler_out, f, indent=2)
         logging.info("Saved scaler params to %s", scaler_output_path)
     return out
 
@@ -388,7 +398,7 @@ def run_training(
         monitor="val_loss",
         mode="min",
         save_top_k=5,
-        save_weights_only=True,
+        save_weights_only=False,
     )
     lr_monitor = LearningRateMonitor(logging_interval="epoch")
 

--- a/abcd/main.py
+++ b/abcd/main.py
@@ -586,6 +586,17 @@ def _build_model_from_config(cfg, flavor, input_size, checkpoint_path, device):
     return model
 
 
+def _copy_input_plots_to_version_dir(source_dir, version_dir):
+    source_dir = Path(source_dir)
+    version_dir = Path(version_dir)
+    version_dir.mkdir(parents=True, exist_ok=True)
+
+    for plot_path in source_dir.glob("inputs_*.png"):
+        dest = version_dir / plot_path.name
+        shutil.copy(str(plot_path), str(dest))
+        logging.info("Copied input plot to %s", dest)
+
+
 def _batched_scores(model, features_tensor, batch_size, flavor, device):
     scores_0 = []
     scores_1 = []
@@ -604,6 +615,199 @@ def _batched_scores(model, features_tensor, batch_size, flavor, device):
     out_0 = np.concatenate(scores_0) if scores_0 else np.array([], dtype=np.float32)
     out_1 = np.concatenate(scores_1) if scores_1 else np.array([], dtype=np.float32)
     return out_0, out_1
+
+def _plot_input_feature_distributions(
+    raw_data,
+    training_features,
+    train_idx,
+    val_idx,
+    output_dir,
+    feature_transforms=None,
+    skip_cols=None,
+):
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    labels = np.asarray(raw_data["label"])
+    weights = np.asarray(raw_data["weight"]) if "weight" in raw_data else np.ones(_data_length(raw_data), dtype=np.float64)
+
+    train_mask = np.zeros(_data_length(raw_data), dtype=bool)
+    val_mask = np.zeros(_data_length(raw_data), dtype=bool)
+    train_mask[np.asarray(train_idx, dtype=np.int64)] = True
+    val_mask[np.asarray(val_idx, dtype=np.int64)] = True
+
+    training_feature_set = set(training_features)
+    feature_transforms = feature_transforms or {}
+    skip_cols = set(skip_cols or [])
+
+    default_skip = {
+        "label", "weight", "dataset_idx", "sample_idx", "split",
+        "dnn_score", "dnn_0_score", "dnn_1_score",
+    }
+    skip_cols |= default_skip
+
+    def _safe_filename(name):
+        return re.sub(r"[^A-Za-z0-9_.-]+", "_", str(name))
+
+    def _weighted_density(values, weights, bins):
+        counts, edges = np.histogram(values, bins=bins, weights=weights, density=False)
+        total = np.sum(counts)
+        if total > 0:
+            counts = counts / total
+        return counts, edges
+
+    def _get_plot_values(arr):
+        arr = np.asarray(arr)
+
+        if arr.dtype == object:
+            try:
+                arr = np.asarray([_flatten_awkward_cell(v) for v in arr], dtype=np.float64)
+            except Exception:
+                return None
+        elif np.issubdtype(arr.dtype, np.number):
+            arr = arr.astype(np.float64, copy=False)
+        else:
+            return None
+
+        arr = arr[np.isfinite(arr)]
+        if arr.size == 0:
+            return None
+        return arr
+
+    all_features = []
+    for key in raw_data.keys():
+        if key in skip_cols:
+            continue
+        vals = _get_plot_values(raw_data[key])
+        if vals is None:
+            continue
+        all_features.append(key)
+
+    all_features = sorted(all_features)
+
+    color_map = {
+        ("bkg", "train"): "tab:blue",
+        ("bkg", "val"): "tab:green",
+        ("sig", "train"): "tab:red",
+        ("sig", "val"): "tab:orange",
+    }
+
+    for feat in all_features:
+        values = _get_plot_values(raw_data[feat])
+        if values is None:
+            logging.info("Skipping non-numeric or empty feature '%s' for input plotting", feat)
+            continue
+
+        finite_mask = np.isfinite(np.asarray(raw_data[feat], dtype=object) if np.asarray(raw_data[feat]).dtype == object else np.asarray(raw_data[feat]))
+        # Rebuild cleaned full-length numeric array for masking
+        full_arr = np.asarray(raw_data[feat])
+        if full_arr.dtype == object:
+            try:
+                full_arr = np.asarray([_flatten_awkward_cell(v) for v in full_arr], dtype=np.float64)
+            except Exception:
+                logging.info("Skipping feature '%s' because it could not be flattened", feat)
+                continue
+        else:
+            full_arr = full_arr.astype(np.float64, copy=False)
+
+        valid_mask = np.isfinite(full_arr)
+        if valid_mask.sum() < 2:
+            logging.info("Skipping feature '%s' because it has fewer than 2 finite values", feat)
+            continue
+
+        plot_vals = full_arr[valid_mask]
+        plot_labels = labels[valid_mask]
+        plot_weights = weights[valid_mask]
+        plot_train_mask = train_mask[valid_mask]
+        plot_val_mask = val_mask[valid_mask]
+
+        vmin = np.min(plot_vals)
+        vmax = np.max(plot_vals)
+
+        if not np.isfinite(vmin) or not np.isfinite(vmax):
+            logging.info("Skipping feature '%s' because plotting range is not finite", feat)
+            continue
+
+        if vmin == vmax:
+            eps = 0.5 if vmin == 0 else 0.05 * abs(vmin)
+            vmin -= eps
+            vmax += eps
+
+        bins = np.linspace(vmin, vmax, 51)
+
+        fig, ax = plt.subplots(figsize=(8, 6))
+
+        subsets = [
+            ("bkg", "train", (plot_labels == 0) & plot_train_mask, "Background train"),
+            ("bkg", "val",   (plot_labels == 0) & plot_val_mask,   "Background val"),
+            ("sig", "train", (plot_labels == 1) & plot_train_mask, "Signal train"),
+            ("sig", "val",   (plot_labels == 1) & plot_val_mask,   "Signal val"),
+        ]
+
+        drew_any = False
+        for cls_name, split_name, mask, legend_label in subsets:
+            vals = plot_vals[mask]
+            wts = plot_weights[mask]
+            if len(vals) == 0 or np.sum(wts) <= 0:
+                continue
+
+            counts, edges = _weighted_density(vals, wts, bins=bins)
+            ax.step(
+                edges[:-1],
+                counts,
+                where="post",
+                linewidth=2,
+                color=color_map[(cls_name, split_name)],
+                label=f"{legend_label} (n={len(vals)})",
+            )
+            drew_any = True
+
+        if not drew_any:
+            plt.close(fig)
+            logging.info("Skipping feature '%s' because no drawable subsets were found", feat)
+            continue
+
+        ax.set_title(feat)
+        ax.set_xlabel(feat)
+        ax.set_ylabel("Unit-normalized weighted yield")
+        legend = ax.legend(loc="best")
+        ax.grid(True, alpha=0.3)
+
+        if feat in training_feature_set:
+            transform = feature_transforms.get(feat, "none")
+            training_note = "★ used in training"
+            if transform != "none":
+                training_note += f" (transform: {transform})"
+
+            fig.canvas.draw()
+            if legend is not None:
+                bbox_disp = legend.get_window_extent(fig.canvas.get_renderer())
+                bbox_axes = bbox_disp.transformed(ax.transAxes.inverted())
+                x_text = bbox_axes.x0
+                y_text = max(0.02, bbox_axes.y0 - 0.06)
+            else:
+                x_text = 0.02
+                y_text = 0.02
+
+            ax.text(
+                x_text,
+                y_text,
+                training_note,
+                transform=ax.transAxes,
+                fontsize=10,
+                color="black",
+                ha="left",
+                va="top",
+                bbox=dict(boxstyle="round,pad=0.25", facecolor="gold", alpha=0.25, edgecolor="goldenrod"),
+            )
+
+        output_path = output_dir / f"inputs_{_safe_filename(feat)}.png"
+        plt.tight_layout()
+        plt.savefig(output_path, dpi=150)
+        plt.close()
+
+        logging.info("Saved input feature plot to %s", output_path)
+
 
 def _plot_constraint_var_distribution(data, constraint_var, train_idx, val_idx, output_path):
     labels = np.asarray(data["label"])
@@ -1163,6 +1367,17 @@ def main():
     constraint_plot_path.parent.mkdir(parents=True, exist_ok=True)
     _plot_constraint_var_distribution(data, constraint_var, train_idx, val_idx, constraint_plot_path)
 
+    raw_plot_data = _concat_sig_bkg(raw_sig_data, raw_bkg_data)
+    raw_plot_data = apply_derived_vars(raw_plot_data, derived_vars_cfg)
+    _plot_input_feature_distributions(
+        raw_data=raw_plot_data,
+        training_features=training_features,
+        train_idx=train_idx,
+        val_idx=val_idx,
+        output_dir=Path(cfg.get("output", "simple_abcdisco_output")),
+        feature_transforms=feature_transforms,
+    )
+
     lightning_model = ABCDLightningModule(
         input_size=len(training_features),
         hidden_layers=cfg.get("architecture", [64, 32, 16]),
@@ -1207,6 +1422,19 @@ def main():
     scaler_path_final = version_dir / "scaler_params.json"
     shutil.copy(str(scaler_path), str(scaler_path_final))
     logging.info("Copied scaler params to %s", scaler_path_final)
+
+    # Copy input diagnostic plots to the versioned directory for reference
+    shutil.copy(str(weight_plot_path), str(version_dir / "input_weight_distributions.png"))
+    logging.info("Copied weight distribution plot to %s", version_dir / "input_weight_distributions.png")
+
+    constraint_plot_path_src = Path(cfg.get("output", "simple_abcdisco_output")) / "constraint_var_distribution.png"
+    shutil.copy(str(constraint_plot_path_src), str(version_dir / "constraint_var_distribution.png"))
+    logging.info("Copied constraint var distribution plot to %s", version_dir / "constraint_var_distribution.png")
+
+    _copy_input_plots_to_version_dir(
+        source_dir=Path(cfg.get("output", "simple_abcdisco_output")),
+        version_dir=version_dir,
+    )
 
     logging.info("Running inference...")
     all_checkpoints = _all_checkpoints_from_config(cfg, flavor=flavor)

--- a/abcd/main.py
+++ b/abcd/main.py
@@ -1162,7 +1162,6 @@ def main():
     constraint_plot_path = Path(cfg.get("output", "simple_abcdisco_output")) / "constraint_var_distribution.png"
     constraint_plot_path.parent.mkdir(parents=True, exist_ok=True)
     _plot_constraint_var_distribution(data, constraint_var, train_idx, val_idx, constraint_plot_path)
-    exit()
 
     lightning_model = ABCDLightningModule(
         input_size=len(training_features),

--- a/abcd/main.py
+++ b/abcd/main.py
@@ -14,6 +14,8 @@ import numpy as np
 import torch
 import uproot
 import awkward as ak
+import matplotlib
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from sklearn.metrics import auc, roc_curve
 from sklearn.model_selection import train_test_split
@@ -26,6 +28,9 @@ from pytorch_lightning.loggers import TensorBoardLogger
 
 from dataloader import get_dataloader
 from model import ABCDLightningModule
+
+from torch.utils.tensorboard import SummaryWriter
+from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
 
 MISSING_VALUE = -999.0
 
@@ -375,6 +380,28 @@ def make_dataloaders(data, training_features, constraint_var, batch_size):
 
     return train_loader, val_loader
 
+
+def save_tensorboard_plots(log_dir, output_dir):
+    ea = EventAccumulator(str(log_dir))
+    ea.Reload()
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for tag in ea.Tags().get("scalars", []):
+        events = ea.Scalars(tag)
+        steps  = [e.step  for e in events]
+        values = [e.value for e in events]
+        fig, ax = plt.subplots(figsize=(8, 5))
+        ax.plot(steps, values, linewidth=2)
+        ax.set_xlabel("Epoch")
+        ax.set_ylabel(tag)
+        ax.set_title(tag)
+        ax.grid(True, alpha=0.3)
+        plt.tight_layout()
+        safe_tag = tag.replace("/", "_")
+        plt.savefig(output_dir / f"{safe_tag}.png", dpi=150)
+        plt.close()
+        print(f"Saved {output_dir / safe_tag}.png")
+
 def run_training(
     model,
     train_loader,
@@ -424,6 +451,7 @@ def run_training(
     )
 
     trainer.fit(model, train_dataloaders=train_loader, val_dataloaders=val_loader)
+    save_tensorboard_plots(logger.log_dir, logger.log_dir)
     return trainer
 
 
@@ -647,6 +675,61 @@ def _plot_score_densities(data, flavor, output_path):
     plt.savefig(output_path, dpi=200)
     plt.close()
 
+# Compute permutation importance by shuffling each feature one at a time and measuring
+# the resulting drop in AUC, averaged over n_repeats shuffles. Features with a larger
+# AUC drop are more important to the model's discrimination.
+def compute_permutation_importance(model, feature_matrix, labels, weights, training_features, device, batch_size=8192, n_repeats=3):
+    """Compute permutation importance by shuffling each feature and measuring AUC drop."""
+    def get_auc(features_tensor):
+        all_scores = []
+        with torch.no_grad():
+            for start in range(0, len(features_tensor), batch_size):
+                batch = features_tensor[start:start + batch_size].to(device)
+                logits = model(batch)
+                if logits.ndim == 1:
+                    logits = logits.unsqueeze(-1)
+                scores = torch.sigmoid(logits).cpu().numpy()[:, 0]
+                all_scores.append(scores)
+        scores = np.concatenate(all_scores)
+        fpr, tpr, _ = roc_curve(labels, scores, sample_weight=weights)
+        return auc(fpr, tpr)
+
+    baseline_tensor = torch.from_numpy(feature_matrix)
+    baseline_auc = get_auc(baseline_tensor)
+
+    importances = {}
+    for i, feat in enumerate(training_features):
+        drops = []
+        for _ in range(n_repeats):
+            shuffled = feature_matrix.copy()
+            np.random.shuffle(shuffled[:, i])
+            shuffled_tensor = torch.from_numpy(shuffled)
+            shuffled_auc = get_auc(shuffled_tensor)
+            drops.append(baseline_auc - shuffled_auc)
+        importances[feat] = np.mean(drops)
+
+    return baseline_auc, importances
+
+
+# Plot permutation importance as a horizontal bar chart, sorted by importance.
+# Features that hurt the AUC most when shuffled appear at the top.
+def plot_permutation_importance(baseline_auc, importances, output_path):
+    """Plot permutation importance as a horizontal bar chart sorted by importance."""
+    sorted_feats = sorted(importances, key=importances.get)
+    sorted_vals  = [importances[f] for f in sorted_feats]
+
+    fig, ax = plt.subplots(figsize=(10, max(6, len(sorted_feats) * 0.25)))
+    colors = ["tab:red" if v > 0 else "tab:blue" for v in sorted_vals]
+    ax.barh(sorted_feats, sorted_vals, color=colors)
+    ax.axvline(0, color="black", linewidth=0.8)
+    ax.set_xlabel("Mean AUC drop when feature is shuffled")
+    ax.set_title(f"Permutation Importance (baseline AUC={baseline_auc:.4f})")
+    ax.grid(True, alpha=0.3, axis="x")
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150)
+    plt.close()
+    print(f"Saved {output_path}")
+
 
 def run_inference(args, cfg, flavor, sig_data, bkg_data, training_features, feature_transforms, constraint_var, derived_vars_cfg, is_data=False, inference_data=None):
     logging.info("Starting inference steps...")
@@ -707,6 +790,20 @@ def run_inference(args, cfg, flavor, sig_data, bkg_data, training_features, feat
         _plot_score_densities(full_inference_data, flavor=flavor, output_path=density_path)
         logging.info("Saved ROC plot to %s", roc_path)
         logging.info("Saved score density plot to %s", density_path)
+
+        # Compute and save permutation importance to identify which features the model relies on most
+        importance_path = output_csv.with_name(f"{output_csv.stem}_permutation_importance.png")
+        baseline_auc, importances = compute_permutation_importance(
+            model=model,
+            feature_matrix=feature_matrix,
+            labels=np.asarray(full_inference_data["label"]),
+            weights=np.asarray(full_inference_data["weight"]),
+            training_features=training_features,
+            device=device,
+            batch_size=cfg.get("batch_size", 8192),
+        )
+        plot_permutation_importance(baseline_auc, importances, importance_path)
+        logging.info("Saved permutation importance plot to %s", importance_path)
 
 
 def main():

--- a/abcd/main.py
+++ b/abcd/main.py
@@ -139,6 +139,9 @@ def _read_root_frame(path, branches, dataset_idx, sample_idx):
     with uproot.open(path) as root_file:
         arrays = root_file["Events"].arrays(branches, library="np")
 
+    if not isinstance(arrays, dict):
+        arrays = {name: arrays[name] for name in arrays.dtype.names}
+
     columns = {}
     n_events = None
     for branch in branches:
@@ -209,11 +212,13 @@ def _evaluate_preselection_mask(data, expression):
     return np.asarray(eval(expression, {"__builtins__": {}, "np": np}, local_dict), dtype=bool)
 
 
+# Also return fitted min/max so they can be saved for inference-time scaling
 def _safe_minmax_scale(values, valid_mask):
     scaled = np.zeros_like(values, dtype=np.float64)
     scaler = MinMaxScaler()
-    scaled[valid_mask] = scaler.fit_transform(values[valid_mask].reshape(-1, 1)).ravel()
-    return scaled
+    scaler.fit(values[valid_mask].reshape(-1, 1))
+    scaled[valid_mask] = scaler.transform(values[valid_mask].reshape(-1, 1)).ravel()
+    return scaled, float(scaler.data_min_[0]), float(scaler.data_max_[0])
 
 
 def load_data(paths, features, extra_vars, num_workers=1):
@@ -257,11 +262,11 @@ def load_data(paths, features, extra_vars, num_workers=1):
     return data
 
 
-def preprocess_data(data, training_features, feature_transforms, constraint_var):
+# If scaler_output_path is provided, fitted min/max per feature are saved to JSON for use at inference time
+def preprocess_data(data, training_features, feature_transforms, constraint_var, scaler_output_path=None):
     out = {k: np.asarray(v).copy() for k, v in data.items()}
     cols_to_clean = list(dict.fromkeys(training_features + [constraint_var]))
     present_cols = [col for col in cols_to_clean if col in out]
-
     for col in present_cols:
         arr = np.asarray(out[col])
         if arr.dtype == object:
@@ -270,27 +275,29 @@ def preprocess_data(data, training_features, feature_transforms, constraint_var)
             arr = arr.astype(np.float64, copy=False)
         arr = np.where(np.isfinite(arr), arr, np.nan)
         out[col] = np.nan_to_num(arr, nan=MISSING_VALUE, posinf=MISSING_VALUE, neginf=MISSING_VALUE)
-
+    scaler_params = {}
     for feat in training_features:
         feat_arr = np.asarray(out[feat], dtype=np.float64)
         valid = (feat_arr != MISSING_VALUE) & np.isfinite(feat_arr)
-
         transform = feature_transforms.get(feat, "none")
         if transform == "log":
             positive = valid & (feat_arr > 0)
             feat_arr[valid & ~positive] = MISSING_VALUE
             valid = positive
-
         if transform == "log":
             feat_arr[valid] = np.log(feat_arr[valid])
-
-        out[feat] = _safe_minmax_scale(feat_arr, valid)
-
+        out[feat], fmin, fmax = _safe_minmax_scale(feat_arr, valid)
+        scaler_params[feat] = {"transform": transform, "min": fmin, "max": fmax}
     if constraint_var not in training_features:
         constraint_arr = np.asarray(out[constraint_var], dtype=np.float64)
         valid_constraint = constraint_arr != MISSING_VALUE
-        out[constraint_var] = _safe_minmax_scale(constraint_arr, valid_constraint)
-
+        out[constraint_var], fmin, fmax = _safe_minmax_scale(constraint_arr, valid_constraint)
+        scaler_params[constraint_var] = {"transform": "none", "min": fmin, "max": fmax}
+    if scaler_output_path is not None:
+        import json
+        with open(scaler_output_path, "w") as f:
+            json.dump(scaler_params, f, indent=2)
+        logging.info("Saved scaler params to %s", scaler_output_path)
     return out
 
 def normalize_class_weights(sig_data, bkg_data):
@@ -809,7 +816,9 @@ def main():
         for key in combined_keys
     }
     data = apply_derived_vars(data, derived_vars_cfg)
-    data = preprocess_data(data, training_features, feature_transforms, constraint_var)
+    # Save scaler params alongside the output so inference can apply identical scaling
+    scaler_path = Path(cfg.get("output", "simple_abcdisco_output")) / "scaler_params.json"
+    data = preprocess_data(data, training_features, feature_transforms, constraint_var, scaler_output_path=scaler_path)
 
     if args.infer:
         logging.info("Skipping training. Running inference only...")
@@ -857,6 +866,12 @@ def main():
     )
 
     logging.info("Training finished.")
+
+    # Copy scaler params to the versioned checkpoint directory so they stay with the model
+    checkpoint_path = _latest_checkpoint_from_config(cfg, flavor=flavor)
+    scaler_path_final = _inference_output_dir_from_checkpoint(checkpoint_path) / "scaler_params.json"
+    shutil.copy(str(scaler_path_tmp), str(scaler_path_final))
+    logging.info("Copied scaler params to %s", scaler_path_final)
 
     logging.info("Running inference...")
     run_inference(args, cfg, flavor, raw_sig_data, raw_bkg_data, training_features, feature_transforms, constraint_var, derived_vars_cfg)

--- a/abcd/main.py
+++ b/abcd/main.py
@@ -605,6 +605,98 @@ def _batched_scores(model, features_tensor, batch_size, flavor, device):
     out_1 = np.concatenate(scores_1) if scores_1 else np.array([], dtype=np.float32)
     return out_0, out_1
 
+def _plot_constraint_var_distribution(data, constraint_var, train_idx, val_idx, output_path):
+    labels = np.asarray(data["label"])
+    constraint = np.asarray(data[constraint_var])
+    weights = np.asarray(data["weight"]) if "weight" in data else None
+
+    fig, axes = plt.subplots(2, 2, figsize=(14, 10), gridspec_kw={"height_ratios": [3, 1]})
+
+    for col, (mask, title) in enumerate([
+        (labels == 0, "Background"),
+        (labels == 1, "Signal"),
+    ]):
+        ax_main = axes[0, col]
+        ax_ratio = axes[1, col]
+
+        all_idx = np.where(mask)[0]
+        train_mask_idx = np.intersect1d(all_idx, train_idx)
+        val_mask_idx = np.intersect1d(all_idx, val_idx)
+
+        all_vals = constraint[all_idx]
+        train_vals = constraint[train_mask_idx]
+        val_vals = constraint[val_mask_idx]
+
+        all_w = weights[all_idx] if weights is not None else None
+        train_w = weights[train_mask_idx] if weights is not None else None
+        val_w = weights[val_mask_idx] if weights is not None else None
+
+        bins = np.linspace(np.min(all_vals), np.max(all_vals), 51)
+
+        all_counts, _ = np.histogram(all_vals, bins=bins, weights=all_w, density=False)
+        train_counts, _ = np.histogram(train_vals, bins=bins, weights=train_w, density=False)
+        val_counts, _ = np.histogram(val_vals, bins=bins, weights=val_w, density=False)
+
+        all_counts_norm = all_counts / (all_counts.sum() + 1e-12)
+        train_counts_norm = train_counts / (train_counts.sum() + 1e-12)
+        val_counts_norm = val_counts / (val_counts.sum() + 1e-12)
+
+        bin_centers = 0.5 * (bins[:-1] + bins[1:])
+
+        ax_main.step(bins[:-1], all_counts_norm, where="post", linewidth=2,
+                     color="black", label=f"All ({len(all_vals)})")
+        ax_main.step(bins[:-1], train_counts_norm, where="post", linewidth=2,
+                     color="tab:blue", label=f"Train ({len(train_vals)})")
+        ax_main.step(bins[:-1], val_counts_norm, where="post", linewidth=2,
+                     color="tab:orange", label=f"Val ({len(val_vals)})")
+        ax_main.set_ylabel("Density")
+        ax_main.set_title(f"{title} {constraint_var} distribution")
+        ax_main.legend()
+        ax_main.grid(True, alpha=0.3)
+
+        ratio = np.where(train_counts_norm > 1e-12, val_counts_norm / train_counts_norm, np.nan)
+        ax_ratio.step(bins[:-1], ratio, where="post", linewidth=2, color="black")
+        ax_ratio.axhline(1.0, color="red", linewidth=1, linestyle="--")
+        ax_ratio.set_xlabel(constraint_var)
+        ax_ratio.set_ylabel("Val / Train")
+        ax_ratio.set_title("Val / Train ratio", fontsize=10)
+        ax_ratio.set_ylim(0, 2)
+        ax_ratio.grid(True, alpha=0.3)
+
+    fig.suptitle(f"{constraint_var} train/val split distribution")
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150)
+    plt.close()
+    logging.info("Saved constraint var distribution plot to %s", output_path)
+
+
+def _plot_weight_distributions(sig_data, bkg_data, output_path):
+    sig_weights = np.asarray(sig_data["weight"])
+    bkg_weights = np.asarray(bkg_data["weight"])
+
+    fig, axes = plt.subplots(1, 2, figsize=(14, 6))
+
+    axes[0].hist(sig_weights, bins=50, histtype="step", linewidth=2, color="tab:red")
+    axes[0].set_xlabel("Weight")
+    axes[0].set_ylabel("Counts")
+    axes[0].set_title("Signal weight distribution")
+    axes[0].set_yscale("log")
+    axes[0].grid(True, alpha=0.3)
+
+    axes[1].hist(bkg_weights, bins=50, histtype="step", linewidth=2, color="tab:blue")
+    axes[1].set_xlabel("Weight")
+    axes[1].set_ylabel("Counts")
+    axes[1].set_title("Background weight distribution")
+    axes[1].set_yscale("log")
+    axes[1].grid(True, alpha=0.3)
+
+    fig.suptitle("Input weight distributions")
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150)
+    plt.close()
+    logging.info("Saved weight distribution plot to %s", output_path)
+
+
 def _plot_abcd_plane(data, flavor, constraint_var, output_path, title_suffix=""):
     def profile_overlay(ax, x, y, bins, xrange, weights=None, color='yellow', label='Profile mean'):
         bin_edges = np.linspace(xrange[0], xrange[1], bins + 1)
@@ -877,7 +969,7 @@ def run_inference(args, cfg, flavor, sig_data, bkg_data, training_features, feat
     full_inference_data["split"] = split_col
 
     if is_data:
-        default_out = _inference_output_dir_from_checkpoint(checkpoint_path) / f"predictions_{flavor}_data.csv"
+        default_out = _inference_output_dir_from_checkpoint(checkpoint_path) / f"predictions_{flavor}_{checkpoint_path.stem}_data.csv"
     else:
         default_out = _inference_output_dir_from_checkpoint(checkpoint_path) / f"predictions_{flavor}_{checkpoint_path.stem}.csv"
 
@@ -1037,6 +1129,10 @@ def main():
     raw_sig_data = {k: np.copy(v) for k, v in sig_data.items()}
     raw_bkg_data = {k: np.copy(v) for k, v in bkg_data.items()}
 
+    weight_plot_path = Path(cfg.get("output", "simple_abcdisco_output")) / "input_weight_distributions.png"
+    weight_plot_path.parent.mkdir(parents=True, exist_ok=True)
+    _plot_weight_distributions(sig_data, bkg_data, weight_plot_path)
+
     sig_data, bkg_data = normalize_class_weights(sig_data, bkg_data)
 
     logging.info("Preprocessing data...")
@@ -1062,6 +1158,11 @@ def main():
         constraint_var=constraint_var,
         batch_size=cfg.get("batch_size", 4096),
     )
+
+    constraint_plot_path = Path(cfg.get("output", "simple_abcdisco_output")) / "constraint_var_distribution.png"
+    constraint_plot_path.parent.mkdir(parents=True, exist_ok=True)
+    _plot_constraint_var_distribution(data, constraint_var, train_idx, val_idx, constraint_plot_path)
+    exit()
 
     lightning_model = ABCDLightningModule(
         input_size=len(training_features),

--- a/abcd/model.py
+++ b/abcd/model.py
@@ -86,7 +86,7 @@ class ABCDLightningModule(pl.LightningModule):
         self.lr_scheduler_patience = lr_scheduler_patience
         self.lr_scheduler_factor = lr_scheduler_factor
         self.lr_scheduler_min_lr = lr_scheduler_min_lr
-        
+
         self.save_hyperparameters()
 
     def forward(self, x):

--- a/abcd/model.py
+++ b/abcd/model.py
@@ -141,14 +141,14 @@ class ABCDLightningModule(pl.LightningModule):
                     bkg_score_0,
                     bkg_constraint,
                     bkg_weights,
-                    power=2,
+                    power=1,
                 )
         else:
             bkg_score_1 = bkg_scores[:, 1]
             if (torch.max(bkg_score_0) - torch.min(bkg_score_0) > 1e-8) and (
                 torch.max(bkg_score_1) - torch.min(bkg_score_1) > 1e-8
             ):
-                disco_term = distance_corr(bkg_score_0, bkg_score_1, bkg_weights, power=2)
+                disco_term = distance_corr(bkg_score_0, bkg_score_1, bkg_weights, power=1)
 
         total_loss = (
             self.bce_weight * bce + self.disco_lambda * disco_term

--- a/abcd/single/config_uf_2l1fj_run2.yaml
+++ b/abcd/single/config_uf_2l1fj_run2.yaml
@@ -2,138 +2,66 @@ sig_base_path: "/home/users/kmohrman/vbs_vvh/ewkcoffea_for_vbs_vvh/ewkcoffea/ana
 bkg_base_path: "/home/users/kmohrman/vbs_vvh/ewkcoffea_for_vbs_vvh/ewkcoffea/analysis/vbs_vvh/histos/"
 data_base_path: "/home/users/kmohrman/vbs_vvh/ewkcoffea_for_vbs_vvh/ewkcoffea/analysis/vbs_vvh/histos/"
 
-#sig_path: ["siphontest_jun12_2l_r2_sigSM.root"]
-#sig_path: ["siphontest_jun12_2l_r2_sigC2V.root"]
-#sig_path: ["siphontest_jun12_2l_r2_sigC3.root"]
-sig_path: ["siphontest_jun12_2l_r2_sigSM.root", "siphontest_jun12_2l_r2_sigC2V.root", "siphontest_jun12_2l_r2_sigC3.root"]
-bkg_path: ["siphontest_jun12_2l_r2_dy.root", "siphontest_jun12_2l_r2_tt.root"]
+sig_path: ["siphontest_jun29_newDY_mHi_00_sig.root"]
+bkg_path: ["siphontest_jun29_newDY_mHi_00_bkg.root"]
 
 training_features:
-  #- abs_ch_sum_3l: minmax
-  - abs_pdgid_sum: minmax
-  - absdeta_max_any: minmax
-  #- absdeta_max_fwd: minmax
-  - absdphi_j0anyj1any: minmax
-  #- absdphi_j0centj1cent: minmax
-  #- absdphi_j0fwdj1fwd: minmax
-  #- bbscore0_bscore: minmax
-  #- bbscore1_bscore: minmax
-  - dr_fj0l0: minmax
-  #- dr_j0anyj1any: minmax
-  #- dr_j0centj1cent: minmax
-  #- dr_j0fwdj1fwd: minmax
-  - dr_l0l1: minmax
-  - dr_lj_max: minmax
-  - dr_lj_min: minmax
-  #- dr_ljnvbs_max: minmax
-  #- dr_ljnvbs_min: minmax
-  - fj0_abseta: minmax
-  #- fj0_mass: log
-  - fj0_mparticlenet: log
-  #- fj0_msoftdrop: log
-  - fj0_pNetH4qvsQCD: minmax
-  - fj0_pNetHbbvsQCD: minmax
-  - fj0_pNetHccvsQCD: minmax
-  - fj0_pNetQCD: minmax
-  - fj0_pNetTvsQCD: minmax
-  - fj0_pNetWvsQCD: minmax
-  - fj0_pNetZvsQCD: minmax
-  - fj0_phi: minmax
-  - fj0_pt: log
-  - j0any_abseta: minmax
-  - j0any_phi: minmax
-  - j0any_pt: log
-  #- j0central_abseta: minmax
-  #- j0central_phi: minmax
-  #- j0central_pt: log
-  #- j0forward_abseta: minmax
-  #- j0forward_phi: minmax
-  #- j0forward_pt: log
-  #- jbscore0_bscore: minmax
-  #- jbscore1_bscore: minmax
-  #- jj_pairs_atmindr_mjj: log
-  - l0_eta: minmax
-  - l0_iso: minmax
-  - l0_miniiso: minmax
-  - l0_phi: minmax
-  - l0_pt: log
-  ###- l0_truth: log
-  ###- l0_truth_fake_iso: log
-  ###- l0_truth_fake_pt: log
-  ###- l0_truth_real_iso: log
-  ###- l0_truth_real_pt: log
-  - l1_eta: minmax
-  - l1_iso: minmax
-  - l1_miniiso: minmax
-  - l1_phi: minmax
-  - l1_pt: log
-  ###- l1_truth: log
-  ###- l1_truth_fake_iso: log
-  ###- l1_truth_fake_pt: log
-  ###- l1_truth_real_iso: log
-  ###- l1_truth_real_pt: log
-  ###- l2_eta: minmax
-  ###- l2_iso: minmax
-  ###- l2_miniiso: minmax
-  ###- l2_pt: log
-  ###- l2_truth: log
-  ###- l2_truth_fake_iso: log
-  ###- l2_truth_fake_pt: log
-  ###- l2_truth_real_iso: log
-  ###- l2_truth_real_pt: log
-  #- mass_b0b1: log
-  #- mass_bbscore0bbscore1: log
-  #- mass_bmbscore0bmbscore1: log
-  #- mass_j0anyj1any: log
-  #- mass_j0centj1cent: log
-  #- mass_j0fwdj1fwd: log
-  #- mass_jbscore0jbscore1: log
-  #- mass_l0l1: log
-  - met: log
-  - metphi: minmax
-  ###- mjj_max_any: log
-  #- mjj_max_cent: log
-  #- mjj_max_fwd: log
-  #- mjjjall_nearest_t: log
-  #- mjjjany: log
-  #- mjjjcnt: log
-  #- mjjjcnt_nearest_t: log
-  #- mjjjjany: log
-  #- mjjjjcnt: log
-  #- mlb_max: log
-  #- mlb_min: log
-  #- mljjjany: log
-  #- mljjjcnt: log
-  #- mljjjjany: log
-  #- mljjjjcnt: log
-  #- mll_min_afos: log
-  - mll_z: log
-  #- n_ll_sfos: minmax
-  - nbtagsl: minmax
-  - nbtagsm: minmax
-  - nbtagst: minmax
-  #- nfatjets: minmax
-  - njets: minmax
-  - njets_counts: minmax
-  - njets_forward: minmax
-  - njets_tot: minmax
-  ###- nlep_truth_fake: minmax
-  ###- nlep_truth_real: minmax
-  #- nleps: minmax
-  #- nleps_counts: minmax
-  - scalarptsum_jetCent: log
-  - scalarptsum_jetCentFwd: log
-  - scalarptsum_jetFwd: log
-  - scalarptsum_lep: log
-  - scalarptsum_lepmet: log
-  - scalarptsum_lepmetFJ: log
-  - scalarptsum_lepmetFJ10: log
-  - scalarptsum_lepmetalljets: log
-  - scalarptsum_lepmetcentjets: log
-  - scalarptsum_lepmetfwdjets: log
-  - vbs_absdetajj: minmax
-  - vbs_mjj: log
-  - vbs_score: minmax
+  - njets : minmax,
+
+  - l0_pt : log,
+  - l0_eta : minmax,
+  - l0_phi : minmax,
+  - l1_pt : log,
+  - l1_eta : minmax,
+  - l1_phi : minmax,
+
+  - fj0_pt : log,
+  - fj0_gpt_mass2p : minmax,
+  #- fj0_mass : minmax,
+  #- fj0_msoftdrop : minmax,
+  #- fj0_mparticlenet : minmax,
+  - fj0_eta : minmax,
+  - fj0_phi : minmax,
+
+  #- fj0_gptHvsQCD : minmax,
+  #- fj0_gptWvsQCD : minmax,
+  #- fj0_gptZvsQCD : minmax,
+  #- fj0_gptVvsQCD : minmax,
+
+  - met : log,
+  - metphi : minmax,
+
+  #- vbs_mjj : log,
+  - vbs_absdetajj : minmax,
+  #- vbs_score : minmax,
+
+  - vbs1_pt : log,
+  - vbs2_pt : log,
+  - vbs1_eta : minmax,
+  - vbs2_eta : minmax,
+  - vbs1_phi : minmax,
+  - vbs2_phi : minmax,
+
+  - scalarptsum_lepmet : log,
+  - scalarptsum_lepmetFJ0 : log,
+  - scalarptsum_lepmetvbsFJ0 : log,
+  - vectorsum_lepmetvbsFJ0_pt : log,
+
+  - mass_l0l1 : log,
+  - dr_l0l1 : minmax ,
+  - pt_l0l1 :  log,
+  - absdphi_l0l1 : minmax,
+  - absdphi_lepmet : minmax,
+  - dr_lepmet : minmax,
+
+  - mass_jFJ_min : log,
+  - mass_jFJ_max : log,
+  - mass_lj_min : log,
+  - mass_lj_max : log,
+
+  - absdphi_FJ0lepmet : minmax,
+  - nbtagst: minmax,
+
 
 
 derived_vars: {}
@@ -146,17 +74,22 @@ extra_vars:
 #preselection: "(boosted_h_candidate_score >= 0.1) | (boosted_v_candidate_score >= 0.1)"
 #preselection: "nFatJets == 1"
 
-constraint_var: "mjj_max_any"
+#constraint_var: "mjj_max_any"
+constraint_var: "vbs_mjj"
+#constraint_var: "vbs_score"
+#constraint_var: "fj0_gptZvsQCD"
 
 batch_size: 8192 #16384
-learning_rate: 0.0001
-n_epochs: 1000
+learning_rate: 0.01
+n_epochs: 5000
+
+early_stopping_patience: 500
 
 architecture: [64, 32, 16]
+#architecture: [256, 128, 64, 32]
 bce_weight: 1.0
-#disco_lambda: 10.0
-#disco_lambda: 100.0
-disco_lambda: 0.0
+disco_lambda: 30.0
+#disco_lambda: 0.0
 
 use_batchnorm: true
 dropout: 0.2

--- a/abcd/single/config_uf_2l1fj_run2.yaml
+++ b/abcd/single/config_uf_2l1fj_run2.yaml
@@ -1,0 +1,49 @@
+sig_base_path: "/home/users/kmohrman/vbs_vvh/ewkcoffea_for_vbs_vvh/ewkcoffea/analysis/vbs_vvh/histos/"
+bkg_base_path: "/home/users/kmohrman/vbs_vvh/ewkcoffea_for_vbs_vvh/ewkcoffea/analysis/vbs_vvh/histos/"
+data_base_path: "/home/users/kmohrman/vbs_vvh/ewkcoffea_for_vbs_vvh/ewkcoffea/analysis/vbs_vvh/histos/"
+
+sig_path: ["siphontest_2l_r2_sig.root"]
+bkg_path: ["siphontest_2l_r2_dy.root"]
+
+training_features:
+  - fj0_eta: minmax 
+  - fj0_phi: minmax
+  - fj0_pt: log
+  - l0_eta: minmax
+  - l0_phi: minmax
+  - l0_pt: log
+  - l1_eta: minmax
+  - l1_phi: minmax
+  - l1_pt: log
+  - met: log
+  - nbtagsl: minmax
+  - njets: minmax
+
+derived_vars: {}
+auto_include_derived_vars: false
+auto_include_derived_vars_transform: none
+
+extra_vars:
+  - weight
+
+#preselection: "(boosted_h_candidate_score >= 0.1) | (boosted_v_candidate_score >= 0.1)"
+#preselection: "nFatJets == 1"
+
+constraint_var: "mjj_max_any"
+
+batch_size: 8192 #16384
+learning_rate: 0.0001
+n_epochs: 1000
+
+architecture: [64, 32, 16]
+bce_weight: 1.0
+disco_lambda: 10.0
+
+use_batchnorm: true
+dropout: 0.2
+weight_decay: 0.01
+label_smoothing: 0.0
+
+devices: [2]
+
+output: "2l1FJ_NEW_RUN2"

--- a/abcd/single/config_uf_2l1fj_run2.yaml
+++ b/abcd/single/config_uf_2l1fj_run2.yaml
@@ -2,22 +2,139 @@ sig_base_path: "/home/users/kmohrman/vbs_vvh/ewkcoffea_for_vbs_vvh/ewkcoffea/ana
 bkg_base_path: "/home/users/kmohrman/vbs_vvh/ewkcoffea_for_vbs_vvh/ewkcoffea/analysis/vbs_vvh/histos/"
 data_base_path: "/home/users/kmohrman/vbs_vvh/ewkcoffea_for_vbs_vvh/ewkcoffea/analysis/vbs_vvh/histos/"
 
-sig_path: ["siphontest_2l_r2_sig.root"]
-bkg_path: ["siphontest_2l_r2_dy.root"]
+#sig_path: ["siphontest_jun12_2l_r2_sigSM.root"]
+#sig_path: ["siphontest_jun12_2l_r2_sigC2V.root"]
+#sig_path: ["siphontest_jun12_2l_r2_sigC3.root"]
+sig_path: ["siphontest_jun12_2l_r2_sigSM.root", "siphontest_jun12_2l_r2_sigC2V.root", "siphontest_jun12_2l_r2_sigC3.root"]
+bkg_path: ["siphontest_jun12_2l_r2_dy.root", "siphontest_jun12_2l_r2_tt.root"]
 
 training_features:
-  - fj0_eta: minmax 
+  #- abs_ch_sum_3l: minmax
+  - abs_pdgid_sum: minmax
+  - absdeta_max_any: minmax
+  #- absdeta_max_fwd: minmax
+  - absdphi_j0anyj1any: minmax
+  #- absdphi_j0centj1cent: minmax
+  #- absdphi_j0fwdj1fwd: minmax
+  #- bbscore0_bscore: minmax
+  #- bbscore1_bscore: minmax
+  - dr_fj0l0: minmax
+  #- dr_j0anyj1any: minmax
+  #- dr_j0centj1cent: minmax
+  #- dr_j0fwdj1fwd: minmax
+  - dr_l0l1: minmax
+  - dr_lj_max: minmax
+  - dr_lj_min: minmax
+  #- dr_ljnvbs_max: minmax
+  #- dr_ljnvbs_min: minmax
+  - fj0_abseta: minmax
+  #- fj0_mass: log
+  - fj0_mparticlenet: log
+  #- fj0_msoftdrop: log
+  - fj0_pNetH4qvsQCD: minmax
+  - fj0_pNetHbbvsQCD: minmax
+  - fj0_pNetHccvsQCD: minmax
+  - fj0_pNetQCD: minmax
+  - fj0_pNetTvsQCD: minmax
+  - fj0_pNetWvsQCD: minmax
+  - fj0_pNetZvsQCD: minmax
   - fj0_phi: minmax
   - fj0_pt: log
+  - j0any_abseta: minmax
+  - j0any_phi: minmax
+  - j0any_pt: log
+  #- j0central_abseta: minmax
+  #- j0central_phi: minmax
+  #- j0central_pt: log
+  #- j0forward_abseta: minmax
+  #- j0forward_phi: minmax
+  #- j0forward_pt: log
+  #- jbscore0_bscore: minmax
+  #- jbscore1_bscore: minmax
+  #- jj_pairs_atmindr_mjj: log
   - l0_eta: minmax
+  - l0_iso: minmax
+  - l0_miniiso: minmax
   - l0_phi: minmax
   - l0_pt: log
+  ###- l0_truth: log
+  ###- l0_truth_fake_iso: log
+  ###- l0_truth_fake_pt: log
+  ###- l0_truth_real_iso: log
+  ###- l0_truth_real_pt: log
   - l1_eta: minmax
+  - l1_iso: minmax
+  - l1_miniiso: minmax
   - l1_phi: minmax
   - l1_pt: log
+  ###- l1_truth: log
+  ###- l1_truth_fake_iso: log
+  ###- l1_truth_fake_pt: log
+  ###- l1_truth_real_iso: log
+  ###- l1_truth_real_pt: log
+  ###- l2_eta: minmax
+  ###- l2_iso: minmax
+  ###- l2_miniiso: minmax
+  ###- l2_pt: log
+  ###- l2_truth: log
+  ###- l2_truth_fake_iso: log
+  ###- l2_truth_fake_pt: log
+  ###- l2_truth_real_iso: log
+  ###- l2_truth_real_pt: log
+  #- mass_b0b1: log
+  #- mass_bbscore0bbscore1: log
+  #- mass_bmbscore0bmbscore1: log
+  #- mass_j0anyj1any: log
+  #- mass_j0centj1cent: log
+  #- mass_j0fwdj1fwd: log
+  #- mass_jbscore0jbscore1: log
+  #- mass_l0l1: log
   - met: log
+  - metphi: minmax
+  ###- mjj_max_any: log
+  #- mjj_max_cent: log
+  #- mjj_max_fwd: log
+  #- mjjjall_nearest_t: log
+  #- mjjjany: log
+  #- mjjjcnt: log
+  #- mjjjcnt_nearest_t: log
+  #- mjjjjany: log
+  #- mjjjjcnt: log
+  #- mlb_max: log
+  #- mlb_min: log
+  #- mljjjany: log
+  #- mljjjcnt: log
+  #- mljjjjany: log
+  #- mljjjjcnt: log
+  #- mll_min_afos: log
+  - mll_z: log
+  #- n_ll_sfos: minmax
   - nbtagsl: minmax
+  - nbtagsm: minmax
+  - nbtagst: minmax
+  #- nfatjets: minmax
   - njets: minmax
+  - njets_counts: minmax
+  - njets_forward: minmax
+  - njets_tot: minmax
+  ###- nlep_truth_fake: minmax
+  ###- nlep_truth_real: minmax
+  #- nleps: minmax
+  #- nleps_counts: minmax
+  - scalarptsum_jetCent: log
+  - scalarptsum_jetCentFwd: log
+  - scalarptsum_jetFwd: log
+  - scalarptsum_lep: log
+  - scalarptsum_lepmet: log
+  - scalarptsum_lepmetFJ: log
+  - scalarptsum_lepmetFJ10: log
+  - scalarptsum_lepmetalljets: log
+  - scalarptsum_lepmetcentjets: log
+  - scalarptsum_lepmetfwdjets: log
+  - vbs_absdetajj: minmax
+  - vbs_mjj: log
+  - vbs_score: minmax
+
 
 derived_vars: {}
 auto_include_derived_vars: false
@@ -37,7 +154,9 @@ n_epochs: 1000
 
 architecture: [64, 32, 16]
 bce_weight: 1.0
-disco_lambda: 10.0
+#disco_lambda: 10.0
+#disco_lambda: 100.0
+disco_lambda: 0.0
 
 use_batchnorm: true
 dropout: 0.2

--- a/abcd/utilities.py
+++ b/abcd/utilities.py
@@ -6,11 +6,11 @@ def distance_corr(
         var_2:torch.tensor,
         normedweight:torch.tensor,
         power=1,
-        )->torch.tensor:
-    
+) -> torch.tensor:
+
     # Normalize the weights
     normedweight = normedweight/torch.sum(normedweight)*len(var_1)
-    
+
     xx = var_1.view(-1, 1).repeat(1, len(var_1)).view(len(var_1),len(var_1))
     yy = var_1.repeat(len(var_1),1).view(len(var_1),len(var_1))
     amat = (xx-yy).abs()
@@ -33,9 +33,9 @@ def distance_corr(
     AAavg = torch.mean(Amat*Amat*normedweight,dim=1)
     BBavg = torch.mean(Bmat*Bmat*normedweight,dim=1)
 
-    if(power==1):
+    if (power==1):
         dCorr=(torch.mean(ABavg*normedweight))/torch.sqrt((torch.mean(AAavg*normedweight)*torch.mean(BBavg*normedweight)))
-    elif(power==2):
+    elif (power==2):
         dCorr=(torch.mean(ABavg*normedweight))**2/(torch.mean(AAavg*normedweight)*torch.mean(BBavg*normedweight))
     else:
         dCorr=((torch.mean(ABavg*normedweight))/torch.sqrt((torch.mean(AAavg*normedweight)*torch.mean(BBavg*normedweight))))**power
@@ -74,17 +74,17 @@ def __get_abcd_random_cuts(var1, var2, n_events_min, max_tries=1_000_000_000):
         rand_cut_x = np.random.uniform(x_min, x_max)
         rand_cut_y = np.random.uniform(y_min, y_max)
         rand_cuts = [rand_cut_x, rand_cut_y]
-        
+
         check = __check_number_of_events(
             var1,
             var2,
             rand_cuts,
             n_events_min,
         )
-        
+
         if check:
             return rand_cuts
-    
+
     raise ValueError(f"Could not find a suitable set of cuts after {max_tries} tries")
 
 def closure(var_1, var_2, weights, labels, symmetrize, n_events_min=10):


### PR DESCRIPTION
This PR adds some updates to the ABCD code:
* Set the `power` to 1, as suggested in Issue #103 
* Write out a json of the training features and the min/max values (so that this can be read in with the model for performing evaluations later) 
* Add a computation of the feature importance (based on change to AUC due to shuffling the values associated with the feature) and dump this information to a plot in the output dir. 
* Copy the plots (loss, ROC, etc, from the fancy dashboard) to the output directory, so that they can be accessed easily after the training. 
* Add plots for inputs (input features, distributions of weights) 
* Add a couple new plots to the inference step (2d plots, and a plot showing the de-correlation in 1d (which has constrained variable on x axis, and shows the distribution overlayed in 4 slices based on output score)) for each checkpoint, and copy these to the versioned output dir also. 
* Copy the input config to the output directory also (for reference) 
* Turn off the `save_weights_only`, so that the relevant info can be loaded for performing evaluations later. 
* Add v136 configuration file for the 2l UF channel (note: commit message wrongly says v126) 
* Some minor formatting cleanups for `model.py` and `utility.py` to make Flake8 happy (since the utilities and model py files have to be copied to ewkcoffea for doing the evaluations there, and that repo has flake8 in the CI) 