### PR TITLE
updated ggZZ xs to match HZZ

### DIFF
--- a/preselection/etc/xsec_ref.py
+++ b/preselection/etc/xsec_ref.py
@@ -38,13 +38,13 @@ xsec_dict = {
             "DYto2E-2Jets_Bin-MLL-50_TuneCP5_13p6TeV": 2244.0,
             "DYto2Tau-2Jets_Bin-MLL-50_TuneCP5_13p6TeV": 2219.0,
 
-            #Used XSDB value multiplied by BR
-            "GluGluToContinto2Zto2E2Mu_TuneCP5_13p6TeV": 0.01384, # BR = 0.002264
-            "GluGlutoContinto2Zto4E_TuneCP5_13p6TeV": 0.00346, # BR = 0.001131
-            "GluGlutoContinto2Zto4Mu_TuneCP5_13p6TeV": 0.00406, # BR = 0.001133
-            "GluGlutoContinto2Zto4Tau_TuneCP5_13p6TeV": 0.00347, # BR = 0.00135
-            "GluGluToContinto2Zto2E2Tau_TuneCP5_13p6TeV": 0.01386, # BR = 0.002267
-            "GluGluToContinto2Zto2Mu2Tau_TuneCP5_13p6TeV": 0.01387, # BR = 0.002269
+            # https://github.com/CJLST/ZZAnalysis/blob/Run3/NanoAnalysis/test/prod/samplesNano_2024_MC.csv
+            "GluGlutoContinto2Zto4E_TuneCP5_13p6TeV": 0.00305851,
+            "GluGlutoContinto2Zto4Mu_TuneCP5_13p6TeV": 0.00303575,
+            "GluGlutoContinto2Zto4Tau_TuneCP5_13p6TeV": 0.00303575,
+            "GluGluToContinto2Zto2E2Mu_TuneCP5_13p6TeV": 0.00624157,
+            "GluGluToContinto2Zto2E2Tau_TuneCP5_13p6TeV": 0.00624157,
+            "GluGluToContinto2Zto2Mu2Tau_TuneCP5_13p6TeV": 0.00624157,
             
             # QCD-HT (obtained by Cristina manually with genXsecAnalyzer) - Cristina Mantilla Suarez at Virginia (see comment from Lara in issue #45)
             "QCD-4Jets_Bin-HT-40to70_TuneCP5_13p6TeV": 311600000.0,


### PR DESCRIPTION
ggZZ xs are slightly larger than what is used in HZZ - they have been updated such that they now match

https://github.com/CJLST/ZZAnalysis/blob/Run3/NanoAnalysis/test/prod/samplesNano_2024_MC.csv#L45

