### PR TITLE
Corrections & systematics: JEC, JES, JER, Type-1 PuppiMET, and weightsyst_ naming

### DIFF
--- a/preselection/src/corrections.cpp
+++ b/preselection/src/corrections.cpp
@@ -62,7 +62,7 @@ RNode applyJetMassResolution(const std::unordered_map<std::string, float>& jmr_f
                              RNode df) {
     auto eval = [jmr_factor, jmr_sigma_rel](std::string year,
                              RVec<float> msd,
-                             RVec<int> genJet_idx, RVec<float> genJet_mass,
+                             RVec<short> genJet_idx, RVec<float> genJet_mass,
                              unsigned int lumi, unsigned long long event) {
         auto it = jmr_factor.find(year);
         if (it == jmr_factor.end()) {
@@ -146,9 +146,9 @@ RNode applyMETPhiCorrections(RNode df, bool isData) {
                 std::cout << "Warning: MET correction set for year " << year << " not found. Skipping MET phi corrections." << std::endl;
                 warned_years.insert(year);
             }
-            return std::make_pair(pt_corr, phi_corr);
+            return std::make_pair(static_cast<float>(pt_corr), static_cast<float>(phi_corr));
         }
-        
+
         std::string pt_corr_name = isData ? "pt_metphicorr_puppimet_data" : "pt_metphicorr_puppimet_mc";
         std::string phi_corr_name = isData ? "phi_metphicorr_puppimet_data" : "phi_metphicorr_puppimet_mc";
 
@@ -158,7 +158,7 @@ RNode applyMETPhiCorrections(RNode df, bool isData) {
         pt_corr = metCorrections.at(year).at(pt_corr_name)->evaluate({pt_to_pass, phi, static_cast<double>(npvs), static_cast<double>(run)});
         phi_corr = metCorrections.at(year).at(phi_corr_name)->evaluate({pt_to_pass, phi, static_cast<double>(npvs), static_cast<double>(run)});
         
-        return std::make_pair(pt_corr, phi_corr);
+        return std::make_pair(static_cast<float>(pt_corr), static_cast<float>(phi_corr));
     };
     return df.Define("_MET_phicorr", eval_correction, {"year", "PuppiMET_pt", "PuppiMET_phi", "PV_npvs", "run"})
             .Define("met_pt", "_MET_phicorr.first")            
@@ -175,13 +175,13 @@ RNode applyMETUnclusteredCorrections(RNode df, std::string variation) {
     if (variation == "up") {
         return df.Define("_MET_uncert_dx", "met_pt * TMath::Cos(met_phi) + MET_MetUnclustEnUpDeltaX")
                 .Define("_MET_uncert_dy", "met_pt * TMath::Sin(met_phi) + MET_MetUnclustEnUpDeltaY")
-                .Redefine("met_pt", "TMath::Sqrt(_MET_uncert_dx * _MET_uncert_dx + _MET_uncert_dy * _MET_uncert_dy)");
+                .Redefine("met_pt", "(float)TMath::Sqrt(_MET_uncert_dx * _MET_uncert_dx + _MET_uncert_dy * _MET_uncert_dy)");
     }
-    
+
     else if (variation == "down") {
         return df.Define("_MET_uncert_dx", "met_pt * TMath::Cos(met_phi) - MET_MetUnclustEnUpDeltaX")
                 .Define("_MET_uncert_dy", "met_pt * TMath::Sin(met_phi) - MET_MetUnclustEnUpDeltaY")
-                .Redefine("met_pt", "TMath::Sqrt(_MET_uncert_dx * _MET_uncert_dx + _MET_uncert_dy * _MET_uncert_dy)");
+                .Redefine("met_pt", "(float)TMath::Sqrt(_MET_uncert_dx * _MET_uncert_dx + _MET_uncert_dy * _MET_uncert_dy)");
     }
     return df;
 }
@@ -209,7 +209,7 @@ FIXME: this needs to be updated to the new recommendation: https://indico.cern.c
 
 NanoAOD branches consumed:
   Jet_pt, Jet_mass, Jet_eta, Jet_phi, Jet_area, Jet_rawFactor, Jet_neEmEF, Jet_chEmEF,
-  fixedGridRhoFastjetAll, run, year
+  Rho_fixedGridRhoFastjetAll, run, year
 */
 
 namespace {
@@ -311,7 +311,7 @@ RNode applyJetEnergyCorrections(const std::unordered_map<std::string, correction
     return df
         .Define("Jet_jecFactor", compute_factor,
                 {"year", "Jet_pt", "Jet_eta", "Jet_area", "Jet_rawFactor",
-                 "fixedGridRhoFastjetAll", "run"})
+                 "Rho_fixedGridRhoFastjetAll", "run"})
         .Define("_jec_metProp", met_propagate,
                 {"Jet_pt", "Jet_phi", "Jet_jecFactor",
                  "Jet_neEmEF", "Jet_chEmEF", "met_pt", "met_phi"})
@@ -406,7 +406,7 @@ RNode applyFatJetEnergyCorrections(const std::unordered_map<std::string, correct
     return df
         .Define("FatJet_jecFactor", compute_factor,
                 {"year", "FatJet_pt", "FatJet_eta", "FatJet_area", "FatJet_rawFactor",
-                 "fixedGridRhoFastjetAll", "run"})
+                 "Rho_fixedGridRhoFastjetAll", "run"})
         .Redefine("FatJet_pt",   "FatJet_pt   * FatJet_jecFactor")
         .Redefine("FatJet_mass", "FatJet_mass * FatJet_jecFactor")
         // Keep FatJet_rawFactor self-consistent against the new pt/mass.
@@ -524,7 +524,7 @@ RNode applyJetEnergyResolution(const std::unordered_map<std::string, correction:
     auto compute_smear = [cset_jerc, cset_jer_smear, jer_res_map, jer_sf_map, vary](
             std::string year,
             RVec<float> pt, RVec<float> eta,
-            RVec<int> genJet_idx, RVec<float> genJet_pt,
+            RVec<short> genJet_idx, RVec<float> genJet_pt,
             float rho, unsigned long long event) {
 
         RVec<float> factor(pt.size(), 1.0f);
@@ -559,13 +559,15 @@ RNode applyJetEnergyResolution(const std::unordered_map<std::string, correction:
             return factor;
         }
 
+        const bool sf_has_pt = (sf->inputs().size() >= 3);
         for (size_t i = 0; i < pt.size(); ++i) {
             const float gen_pt = (genJet_idx[i] >= 0 && genJet_idx[i] < (int)genJet_pt.size())
                                      ? genJet_pt[genJet_idx[i]] : -1.0f;
             double r  = res->evaluate({(double)eta[i], (double)pt[i], (double)rho});
-            double s  = sf ->evaluate({(double)eta[i], vary});
+            double s  = sf_has_pt ? sf->evaluate({(double)eta[i], (double)pt[i], vary})
+                                  : sf->evaluate({(double)eta[i], vary});
             double sm = smear->evaluate({(double)pt[i], (double)eta[i], (double)gen_pt,
-                                         (double)rho, (double)((int)event), r, s});
+                                         (double)rho, (int)event, r, s});
             factor[i] = static_cast<float>(sm);
         }
         return factor;
@@ -591,7 +593,7 @@ RNode applyJetEnergyResolution(const std::unordered_map<std::string, correction:
     return df
         .Define("Jet_jerFactor", compute_smear,
                 {"year", "Jet_pt", "Jet_eta", "Jet_genJetIdx", "GenJet_pt",
-                 "fixedGridRhoFastjetAll", "event"})
+                 "Rho_fixedGridRhoFastjetAll", "event"})
         .Define("_Jet_pt_preJER", "Jet_pt")
         .Define("_jer_metProp", met_propagate_jer,
                 {"_Jet_pt_preJER", "Jet_jerFactor", "Jet_phi",
@@ -622,7 +624,7 @@ RNode applyFatJetEnergyResolution(const std::unordered_map<std::string, correcti
     auto compute_smear = [cset_jerc, cset_jer_smear, jer_res_map, jer_sf_map, vary](
             std::string year,
             RVec<float> pt, RVec<float> eta,
-            RVec<int> genJet_idx, RVec<float> genJet_pt,
+            RVec<short> genJet_idx, RVec<float> genJet_pt,
             float rho, unsigned long long event) {
 
         RVec<float> factor(pt.size(), 1.0f);
@@ -657,13 +659,15 @@ RNode applyFatJetEnergyResolution(const std::unordered_map<std::string, correcti
             return factor;
         }
 
+        const bool sf_has_pt = (sf->inputs().size() >= 3);
         for (size_t i = 0; i < pt.size(); ++i) {
             const float gen_pt = (genJet_idx[i] >= 0 && genJet_idx[i] < (int)genJet_pt.size())
                                      ? genJet_pt[genJet_idx[i]] : -1.0f;
             double r  = res->evaluate({(double)eta[i], (double)pt[i], (double)rho});
-            double s  = sf ->evaluate({(double)eta[i], vary});
+            double s  = sf_has_pt ? sf->evaluate({(double)eta[i], (double)pt[i], vary})
+                                  : sf->evaluate({(double)eta[i], vary});
             double sm = smear->evaluate({(double)pt[i], (double)eta[i], (double)gen_pt,
-                                         (double)rho, (double)((int)event), r, s});
+                                         (double)rho, (int)event, r, s});
             factor[i] = static_cast<float>(sm);
         }
         return factor;
@@ -672,7 +676,7 @@ RNode applyFatJetEnergyResolution(const std::unordered_map<std::string, correcti
     return df
         .Define("FatJet_jerFactor", compute_smear,
                 {"year", "FatJet_pt", "FatJet_eta", "FatJet_genJetAK8Idx", "GenJetAK8_pt",
-                 "fixedGridRhoFastjetAll", "event"})
+                 "Rho_fixedGridRhoFastjetAll", "event"})
         .Redefine("FatJet_pt",   "FatJet_pt   * FatJet_jerFactor")
         .Redefine("FatJet_mass", "FatJet_mass * FatJet_jerFactor");
 }

--- a/preselection/src/corrections.cpp
+++ b/preselection/src/corrections.cpp
@@ -606,7 +606,11 @@ RNode applyJESVariations(RNode df) {
     return df;
 }
 
+static bool g_storeSysts = true;
+void setStoreSysts(bool v) { g_storeSysts = v; }
+
 std::vector<std::string> jesVariationSuffixes() {
+    if (!g_storeSysts) return {};
     std::vector<std::string> out;
     out.reserve(kJESRegroupedSources.size() * kJESDirections.size());
     for (const auto& src : kJESRegroupedSources) {
@@ -985,7 +989,7 @@ RNode applyMCCorrections(RNode df_) {
                                      df, /*variation=*/"nominal");
     // JES uncertainties — 11 Regrouped V2 sources × {Up, Dn} as suffixed branches.
     // Must run after the nominal JEC+JER so the shift sits on top of the corrected baseline.
-    df = applyJESVariations(df);
+    if (g_storeSysts) df = applyJESVariations(df);
     // JMS / JMR on FatJet_msoftdrop. Currently no-op: centrals are placeholders
     // (shift = 0 GeV, factor = 1.0). Replace jetMassScale_central / jetMassResolution_central
     // in corrections.h with the values derived from the per-analysis calibration fit.

--- a/preselection/src/corrections.cpp
+++ b/preselection/src/corrections.cpp
@@ -18,42 +18,90 @@ RVec<bool> isbTagTight(std::string year, RVec<float> btag_score) {
     return btag_score > btaggingWPMap_Tight.at(year);
 }
 
-// /*
-// ############################################
-// JET MASS SCALE CORRECTIONS
-// ############################################
-// */
+/*
+############################################
+JET MASS SCALE (JMS) AND RESOLUTION (JMR)
+############################################
 
-// RNode applyJMSCorrections(std::unordered_map<std::string, correction::CorrectionSet> cset_jms, RNode df, std::string variation) { 
-//     auto eval_correction = [cset_jms, variation] (std::string year, float mass) {
-//         if (cset_jms.find(year) == cset_jms.end()) {
-//             return mass;
-//         }
-//         double scaleVal = 1. + 0.05 * cset_jms.at(year).at("JMS")->evaluate({year, variation});
-//         // https://docs.google.com/presentation/d/1C7CqO3Wv3-lYd7vw4IQXq69wmULesTsSniFXXM__ReU
-//         return mass * scaleVal;
-//     };
-//     return df.Redefine("Hbbmass", eval_correction, {"year", "GHiggs_mass"})
-//              .Redefine("Wjetmass", eval_correction, {"year", "GW_mass"});
-// }
+Parametrization is applied on `FatJet_msoftdrop`:
 
-// /*
-// ############################################
-// JET MASS RESOLUTION CORRECTIONS
-// ############################################
-// */
+  JMS  : msd' = max(0, msd + Δshift[year])               // additive shift in GeV
+  JMR  : matched   →  msd' = max(0, m_gen + f * (msd - m_gen))   
+         unmatched →  msd' = max(0, msd * (1 + √max(f²-1,0) * σrel * N(0,1)))
+                      // σrel = 1.0 is a placeholder; replace with the per-era msd
+                      // resolution when JMR is derived. Branch is dead while f == 1.0.
 
-// RNode applyJMRCorrections(std::unordered_map<std::string, correction::CorrectionSet> cset_jmr, RNode df, std::string variation) {
-//     auto eval_correction = [cset_jmr, variation] (std::string year, float mass, unsigned int lumi, unsigned long long event) {
-//         if (cset_jmr.find(year) == cset_jmr.end()) {
-//             return mass;
-//         }
-//         TRandom3 rnd((lumi << 10) + event);
-//         return rnd.Gaus(1, 0.1 * cset_jmr.at(year).at("JMR")->evaluate({year, variation})) * mass;
-//     };
-//     return df.Redefine("Hbbmass", eval_correction, {"year", "GHiggs_mass", "luminosityBlock", "event"})
-//              .Redefine("Wjetmass", eval_correction, {"year", "GW_mass", "luminosityBlock", "event"});
-// }
+Current factors are placeholders (Δshift = 0 GeV and f = 1.0), both reduce to the identity.
+Replace with the calibration outputs once derived. 
+TO DO: add systematic up/down, add a `variation` argument and pass ±1σ shift/scale instead of the central.
+
+*/
+
+RNode applyJetMassScale(const std::unordered_map<std::string, float>& jms_shift, RNode df) {
+    auto eval = [jms_shift](std::string year, RVec<float> msd) {
+        auto it = jms_shift.find(year);
+        if (it == jms_shift.end()) {
+            static std::unordered_set<std::string> warned_years;
+            if (warned_years.insert(year).second) {
+                std::cout << "Warning: JMS shift not defined for year " << year
+                          << ". Skipping." << std::endl;
+            }
+            return msd;
+        }
+        const float shift = it->second;
+        if (shift == 0.0f || msd.empty()) return msd;
+        // apply jet mass cale shift to every fat jet's soft-drop mass in the event
+        for (auto& m : msd) m = std::max(0.0f, m + shift);
+        return msd;
+    };
+    return df.Redefine("FatJet_msoftdrop", eval, {"year", "FatJet_msoftdrop"});
+}
+
+RNode applyJetMassResolution(const std::unordered_map<std::string, float>& jmr_factor,
+                             const std::unordered_map<std::string, float>& jmr_sigma_rel,
+                             RNode df) {
+    auto eval = [jmr_factor, jmr_sigma_rel](std::string year,
+                             RVec<float> msd,
+                             RVec<int> genJet_idx, RVec<float> genJet_mass,
+                             unsigned int lumi, unsigned long long event) {
+        auto it = jmr_factor.find(year);
+        if (it == jmr_factor.end()) {
+            static std::unordered_set<std::string> warned_years;
+            if (warned_years.insert(year).second) {
+                std::cout << "Warning: JMR factor not defined for year " << year
+                          << ". Skipping." << std::endl;
+            }
+            return msd;
+        }
+        const float f = it->second;
+        if (f == 1.0f || msd.empty()) return msd;
+
+        const float widen = std::sqrt(std::max(f * f - 1.0f, 0.0f));
+        // sigma_rel = relative msoftdrop resolution σ(msd)/msd, used by the unmatched
+        // stochastic branch. Per-era placeholder maps jetMassResolution_sigmaRel_central
+        // in corrections.h; replace with the value from the same calibration fit as
+        // jmr_factor. Falls back to 1.0 if the year is missing from the map.
+        auto sr_it = jmr_sigma_rel.find(year);
+        const float sigma_rel = (sr_it != jmr_sigma_rel.end()) ? sr_it->second : 1.0f;
+        TRandom3 rng((static_cast<unsigned long long>(lumi) << 10) ^ event);
+        for (size_t i = 0; i < msd.size(); ++i) {
+            const bool matched = (genJet_idx[i] >= 0
+                                  && genJet_idx[i] < static_cast<int>(genJet_mass.size()));
+            if (matched) {
+                const float m_gen = genJet_mass[genJet_idx[i]];
+                msd[i] = std::max(0.0f, m_gen + f * (msd[i] - m_gen));
+            } else {
+                const float kick = static_cast<float>(rng.Gaus(0.0, 1.0));
+                msd[i] = std::max(0.0f, msd[i] * (1.0f + widen * sigma_rel * kick));
+            }
+        }
+        return msd;
+    };
+    return df.Redefine("FatJet_msoftdrop", eval,
+                       {"year", "FatJet_msoftdrop",
+                        "FatJet_genJetAK8Idx", "GenJetAK8_mass",
+                        "luminosityBlock", "event"});
+}
 
 /*
 ############################################
@@ -133,6 +181,7 @@ RNode applyMETUnclusteredCorrections(RNode df, std::string variation) {
                 .Define("_MET_uncert_dy", "met_pt * TMath::Sin(met_phi) + MET_MetUnclustEnUpDeltaY")
                 .Redefine("met_pt", "TMath::Sqrt(_MET_uncert_dx * _MET_uncert_dx + _MET_uncert_dy * _MET_uncert_dy)");
     }
+    
     else if (variation == "down") {
         return df.Define("_MET_uncert_dx", "met_pt * TMath::Cos(met_phi) - MET_MetUnclustEnUpDeltaX")
                 .Define("_MET_uncert_dy", "met_pt * TMath::Sin(met_phi) - MET_MetUnclustEnUpDeltaY")
@@ -143,149 +192,493 @@ RNode applyMETUnclusteredCorrections(RNode df, std::string variation) {
 
 /*
 ############################################
-JET ENERGY CORRECTIONS
+JET ENERGY CORRECTIONS — nominal 
 ############################################
+
+Recipe (per AK4 jet, year-aware):
+  pt_raw   = (1 - Jet_rawFactor) * Jet_pt     // undo NanoAOD JEC
+  mass_raw = (1 - Jet_rawFactor) * Jet_mass
+
+  factor   = compound(Jet_area, Jet_eta, pt_raw, rho [, run])
+             // compound = L1FastJet * L2Relative * L3Absolute (* L2L3Residual for DATA),
+             // with `inputs_update=[JetPt]` so each stage feeds the next its updated pt.
+  pt_new   = pt_raw   * factor
+  mass_new = mass_raw * factor
+
+Type-I MET is rebuilt on top of the NanoAOD baseline:
+  met_x_new = met_x_old + sum_jets (pt_NanoAOD - pt_new) * cos(phi)
+  met_y_new = met_y_old + sum_jets (pt_NanoAOD - pt_new) * sin(phi)
+where the sum runs over jets with pt_new > 15 GeV and (neEmEF + chEmEF) < 0.9.
+FIXME: this needs to be updated to the new recommendation: https://indico.cern.ch/event/1644923/contributions/6916115/attachments/3211593/5720863/260202_JMEGeneral_Type1METWithNano_Nurfikri.pdf
+
+NanoAOD branches consumed:
+  Jet_pt, Jet_mass, Jet_eta, Jet_phi, Jet_area, Jet_rawFactor, Jet_neEmEF, Jet_chEmEF,
+  fixedGridRhoFastjetAll, run, year
 */
 
-RNode applyJetEnergyCorrections(std::unordered_map<std::string, correction::CorrectionSet> cset_jerc, std::unordered_map<std::string, std::string> jec_prefix_map, std::unordered_map<std::string, std::string> jec_suffix_map, RNode df, std::string JEC_type, std::string variation) {
-    auto eval_correction = [cset_jerc, jec_prefix_map, jec_suffix_map, JEC_type, variation] (std::string year, RVec<float> pt, RVec<float> eta, RVec<float> var) {
-        RVec<float> jec_factors;
+namespace {
+    inline std::string makeCompoundJECName(const std::string& mc_prefix,
+                                           const std::string& algo,
+                                           bool isData) {
+        // jec_prefix_map values end in "_MC" by convention; replace with "_DATA" for data.
+        std::string base = mc_prefix;
+        const std::string mc_tag = "_MC";
+        // check base ends with "_MC" and chop those last 3 characters off
+        if (base.size() >= mc_tag.size() &&
+            base.compare(base.size() - mc_tag.size(), mc_tag.size(), mc_tag) == 0) {
+            base.resize(base.size() - mc_tag.size());
+        }
+        return base + (isData ? "_DATA" : "_MC") + "_L1L2L3Res_" + algo;
+    }
+}
 
-        if (var.size() == 0) {
-            return var;
-        }
-        
-        if (cset_jerc.find(year) == cset_jerc.end()) {
+RNode applyJetEnergyCorrections(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
+                                const std::unordered_map<std::string, std::string>& jec_prefix_map,
+                                const std::unordered_map<std::string, std::string>& jec_suffix_map,
+                                RNode df, bool isData) {
+
+    auto compute_factor = [cset_jerc, jec_prefix_map, jec_suffix_map, isData](
+            std::string year,
+            RVec<float> pt, RVec<float> eta, RVec<float> area, RVec<float> rawFactor,
+            float rho, unsigned int run) {
+
+        RVec<float> factor(pt.size(), 1.0f);
+        if (pt.empty()) return factor;
+
+        auto cs_it = cset_jerc.find(year);
+        auto pf_it = jec_prefix_map.find(year);
+        auto sf_it = jec_suffix_map.find(year);
+        if (cs_it == cset_jerc.end() || pf_it == jec_prefix_map.end() || sf_it == jec_suffix_map.end()) {
             static std::unordered_set<std::string> warned_years;
-            if (warned_years.find(year) == warned_years.end()) {
-                std::cout << "Warning: JEC correction set for year " << year << " not found. Skipping JEC corrections." << std::endl;
-                warned_years.insert(year);
+            if (warned_years.insert(year).second) {
+                std::cout << "Warning: JEC inputs missing for year " << year
+                          << ". Skipping nominal JEC re-application." << std::endl;
             }
-            return var;
-        }
-        
-        if (jec_prefix_map.find(year) == jec_prefix_map.end()) {
-            static std::unordered_set<std::string> warned_years;
-            if (warned_years.find(year) == warned_years.end()) {
-                std::cout << "Warning: JEC prefix map for year " << year << " not found. Skipping JEC corrections." << std::endl;
-                warned_years.insert(year);
-            }
-            return var;
-        }
-        
-        if (jec_suffix_map.find(year) == jec_suffix_map.end()) {
-            static std::unordered_set<std::string> warned_years;
-            if (warned_years.find(year) == warned_years.end()) {
-                std::cout << "Warning: JEC suffix map for year " << year << " not found. Skipping JEC corrections." << std::endl;
-                warned_years.insert(year);
-            }
-            return var;
+            return factor;
         }
 
-        // Construct JEC correction name based on year
-        std::string JEC_name = jec_prefix_map.at(year) + "_" + JEC_type + "_" + jec_suffix_map.at(year);
-
-        for (size_t i = 0; i < var.size(); i++) {
-            if (variation == "up") {
-                jec_factors.push_back(var[i] * (1 + cset_jerc.at(year).at(JEC_name)->evaluate({eta[i], pt[i]})));
+        const std::string compound_name = makeCompoundJECName(pf_it->second, sf_it->second, isData);
+        std::shared_ptr<const correction::CompoundCorrection> compound;
+        try {
+            compound = cs_it->second.compound().at(compound_name);
+        } catch (const std::out_of_range&) {
+            static std::unordered_set<std::string> warned_keys;
+            if (warned_keys.insert(year + "/" + compound_name).second) {
+                std::cout << "Warning: compound JEC '" << compound_name
+                          << "' not found for year " << year
+                          << ". Skipping nominal JEC re-application." << std::endl;
             }
-            else if (variation == "down") {
-                jec_factors.push_back(var[i] * (1 - cset_jerc.at(year).at(JEC_name)->evaluate({eta[i], pt[i]})));
-            }
-            else {
-                return var;
-            }
+            return factor;
         }
-        return jec_factors;
+
+        for (size_t i = 0; i < pt.size(); ++i) {
+            float pt_raw = (1.0f - rawFactor[i]) * pt[i];
+            double sf = 1.0;
+            try {
+                if (isData) {
+                    sf = compound->evaluate({(double)area[i], (double)eta[i],
+                                             (double)pt_raw,  (double)rho,
+                                             (double)run});
+                } else {
+                    sf = compound->evaluate({(double)area[i], (double)eta[i],
+                                             (double)pt_raw,  (double)rho});
+                }
+            } catch (const std::exception& e) {
+                sf = 1.0;
+            }
+            // Multiplicative factor on the *NanoAOD* pt: Jet_pt_new = Jet_pt * factor
+            //   = Jet_pt * (pt_raw / Jet_pt) * sf = (1 - rawFactor) * sf
+            factor[i] = (1.0f - rawFactor[i]) * static_cast<float>(sf);
+        }
+        return factor;
     };
-    
-    auto df_jetcorr = df.Redefine("Jet_pt", eval_correction, {"year", "Jet_pt", "Jet_eta", "Jet_pt"})
-                        .Redefine("Jet_mass", eval_correction, {"year", "Jet_pt", "Jet_eta", "Jet_mass"})
-                        .Redefine("FatJet_pt", eval_correction, {"year", "FatJet_pt", "FatJet_eta", "FatJet_pt"})
-                        .Redefine("FatJet_mass", eval_correction, {"year", "FatJet_pt", "FatJet_eta", "FatJet_mass"});
 
-    auto correctmet = [JEC_type](std::string year, RVec<float> Jet_pt, RVec<float> jet_phi, RVec<float> jet_pt, float met_pt, float met_phi) {
-        if (Jet_pt.empty()) {
-            return met_pt;
+    auto met_propagate = [](RVec<float> pt_old, RVec<float> phi,
+                            RVec<float> factor, RVec<float> neEmEF, RVec<float> chEmEF,
+                            float met_pt, float met_phi) {
+        // Type-I MET propagation: replace the contribution of NanoAOD-corrected jets
+        // (pt_old) with re-corrected jets (pt_new = pt_old * factor) in the MET sum.
+        double px = met_pt * std::cos(met_phi);
+        double py = met_pt * std::sin(met_phi);
+        for (size_t i = 0; i < pt_old.size(); ++i) {
+            const float pt_new = pt_old[i] * factor[i];
+            if (pt_new <= 15.0f) continue;                       // Type-I threshold
+            if ((neEmEF[i] + chEmEF[i]) > 0.9f) continue;        // EM-fraction veto
+            const double dpt = static_cast<double>(pt_old[i] - pt_new);
+            px += dpt * std::cos(phi[i]);
+            py += dpt * std::sin(phi[i]);
         }
-        float px = met_pt * TMath::Cos(met_phi);
-        float py = met_pt * TMath::Sin(met_phi);
-        for (size_t i = 0; i < Jet_pt.size(); i++) {
-            px += (Jet_pt[i] - jet_pt[i]) * TMath::Cos(jet_phi[i]);
-            py += (Jet_pt[i] - jet_pt[i]) * TMath::Sin(jet_phi[i]);
-        }
-        return (float)TMath::Sqrt(px * px + py * py);
+        return std::make_pair(static_cast<float>(std::sqrt(px*px + py*py)),
+                              static_cast<float>(std::atan2(py, px)));
     };
 
-    return df_jetcorr.Redefine("met_pt", correctmet, {"year", "Jet_pt", "Jet_phi", "Jet_pt", "met_pt", "met_phi"});
+    return df
+        .Define("Jet_jecFactor", compute_factor,
+                {"year", "Jet_pt", "Jet_eta", "Jet_area", "Jet_rawFactor",
+                 "fixedGridRhoFastjetAll", "run"})
+        .Define("_jec_metProp", met_propagate,
+                {"Jet_pt", "Jet_phi", "Jet_jecFactor",
+                 "Jet_neEmEF", "Jet_chEmEF", "met_pt", "met_phi"})
+        .Redefine("met_pt",   "_jec_metProp.first")
+        .Redefine("met_phi",  "_jec_metProp.second")
+        .Redefine("Jet_pt",   "Jet_pt   * Jet_jecFactor")
+        .Redefine("Jet_mass", "Jet_mass * Jet_jecFactor")
+        // Reset rawFactor so downstream callers see a self-consistent (pt, mass, rawFactor) triple.
+        // pt_new * (1 - rawFactor_new) == pt_raw  =>  rawFactor_new = 1 - (1-rawFactor_old)/Jet_jecFactor
+        .Redefine("Jet_rawFactor",
+                  [](RVec<float> rawFactor, RVec<float> factor) {
+                      RVec<float> out(rawFactor.size());
+                      for (size_t i = 0; i < rawFactor.size(); ++i) {
+                          out[i] = (factor[i] > 0.f)
+                                       ? 1.0f - (1.0f - rawFactor[i]) / factor[i]
+                                       : rawFactor[i];
+                      }
+                      return out;
+                  },
+                  {"Jet_rawFactor", "Jet_jecFactor"});
 }
 
 /*
 ############################################
-JET ENERGY RESOLUTION
+FAT JET (AK8) ENERGY CORRECTIONS — nominal 
 ############################################
+
+Same recipe as AK4 (raw recovery + L1L2L3Res compound from fatJet_jerc.json.gz, with the
+AK8PFPuppi algo). Operates on FatJet_* branches. Does NOT propagate to MET — PuppiMET is
+built from AK4 jets only.
 */
 
-RNode applyJetEnergyResolution(std::unordered_map<std::string, correction::CorrectionSet> cset_jerc, std::unordered_map<std::string, correction::CorrectionSet> cset_jer_smear, std::unordered_map<std::string, std::string> jer_res_map, std::unordered_map<std::string, std::string> jer_sf_map, RNode df, std::string variation) {
-    auto eval_correction = [cset_jerc, cset_jer_smear, jer_res_map, jer_sf_map, variation] (std::string year, RVec<float> pt, RVec<float> eta, RVec<int> genJet_idx, RVec<float> genJet_pt, float rho, unsigned long long event, RVec<float> var) {
-        RVec<float> jer_factors;
-        std::string vary = (variation == "nominal") ? "nom" : variation;
-        
-        if (var.size() == 0) {
-            return var;
-        }
-        
-        if (cset_jerc.find(year) == cset_jerc.end()) {
+RNode applyFatJetEnergyCorrections(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
+                                   const std::unordered_map<std::string, std::string>& jec_prefix_map,
+                                   const std::unordered_map<std::string, std::string>& jec_suffix_map,
+                                   RNode df, bool isData) {
+
+    auto compute_factor = [cset_jerc, jec_prefix_map, jec_suffix_map, isData](
+            std::string year,
+            RVec<float> pt, RVec<float> eta, RVec<float> area, RVec<float> rawFactor,
+            float rho, unsigned int run) {
+
+        RVec<float> factor(pt.size(), 1.0f);
+        if (pt.empty()) return factor;
+
+        auto cs_it = cset_jerc.find(year);
+        auto pf_it = jec_prefix_map.find(year);
+        auto sf_it = jec_suffix_map.find(year);
+        if (cs_it == cset_jerc.end() || pf_it == jec_prefix_map.end() || sf_it == jec_suffix_map.end()) {
             static std::unordered_set<std::string> warned_years;
-            if (warned_years.find(year) == warned_years.end()) {
-                std::cout << "Warning: JER correction set for year " << year << " not found. Skipping JER corrections." << std::endl;
-                warned_years.insert(year);
+            if (warned_years.insert(year).second) {
+                std::cout << "Warning: AK8 JEC inputs missing for year " << year
+                          << ". Skipping nominal AK8 JEC re-application." << std::endl;
             }
-            return var;
-        }
-        
-        if (cset_jer_smear.find("jer_smear") == cset_jer_smear.end()) {
-            static bool warned = false;
-            if (!warned) {
-                std::cout << "Warning: JER smear correction set not found. Skipping JER corrections." << std::endl;
-                warned = true;
-            }
-            return var;
-        }
-        
-        if (jer_res_map.find(year) == jer_res_map.end()) {
-            static std::unordered_set<std::string> warned_years;
-            if (warned_years.find(year) == warned_years.end()) {
-                std::cout << "Warning: JER resolution map for year " << year << " not found. Skipping JER corrections." << std::endl;
-                warned_years.insert(year);
-            }
-            return var;
-        }
-        
-        if (jer_sf_map.find(year) == jer_sf_map.end()) {
-            static std::unordered_set<std::string> warned_years;
-            if (warned_years.find(year) == warned_years.end()) {
-                std::cout << "Warning: JER scale factor map for year " << year << " not found. Skipping JER corrections." << std::endl;
-                warned_years.insert(year);
-            }
-            return var;
+            return factor;
         }
 
-        std::string jer_res_name = jer_res_map.at(year);
-        std::string jer_sf_name = jer_sf_map.at(year);
-
-        for (size_t i = 0; i < var.size(); i++) {
-            float genjetpt = genJet_idx[i] >= 0 ? genJet_pt[genJet_idx[i]] : -1;
-            float jer = cset_jerc.at(year).at(jer_res_name)->evaluate({eta[i], pt[i], rho});
-            float jer_sf = cset_jerc.at(year).at(jer_sf_name)->evaluate({eta[i], vary});
-            jer_factors.push_back(var[i] * cset_jer_smear.at("jer_smear").at("JERSmear")->evaluate({pt[i], eta[i], genjetpt, rho, (int)event, jer, jer_sf}));
+        const std::string compound_name = makeCompoundJECName(pf_it->second, sf_it->second, isData);
+        std::shared_ptr<const correction::CompoundCorrection> compound;
+        try {
+            compound = cs_it->second.compound().at(compound_name);
+        } catch (const std::out_of_range&) {
+            static std::unordered_set<std::string> warned_keys;
+            if (warned_keys.insert(year + "/" + compound_name).second) {
+                std::cout << "Warning: AK8 compound JEC '" << compound_name
+                          << "' not found for year " << year
+                          << ". Skipping nominal AK8 JEC re-application." << std::endl;
+            }
+            return factor;
         }
-        
-        return jer_factors;
+
+        for (size_t i = 0; i < pt.size(); ++i) {
+            float pt_raw = (1.0f - rawFactor[i]) * pt[i];
+            double sf = 1.0;
+            try {
+                if (isData) {
+                    sf = compound->evaluate({(double)area[i], (double)eta[i],
+                                             (double)pt_raw,  (double)rho,
+                                             (double)run});
+                } else {
+                    sf = compound->evaluate({(double)area[i], (double)eta[i],
+                                             (double)pt_raw,  (double)rho});
+                }
+            } catch (const std::exception&) {
+                sf = 1.0;
+            }
+            factor[i] = (1.0f - rawFactor[i]) * static_cast<float>(sf);
+        }
+        return factor;
     };
-    
-    return df.Redefine("Jet_pt", eval_correction, {"year", "Jet_pt", "Jet_eta", "Jet_genJetIdx", "GenJet_pt", "fixedGridRhoFastjetAll", "event", "Jet_pt"})
-            .Redefine("Jet_mass", eval_correction, {"year", "Jet_pt", "Jet_eta", "Jet_genJetIdx", "GenJet_pt", "fixedGridRhoFastjetAll", "event", "Jet_mass"});
+
+    return df
+        .Define("FatJet_jecFactor", compute_factor,
+                {"year", "FatJet_pt", "FatJet_eta", "FatJet_area", "FatJet_rawFactor",
+                 "fixedGridRhoFastjetAll", "run"})
+        .Redefine("FatJet_pt",   "FatJet_pt   * FatJet_jecFactor")
+        .Redefine("FatJet_mass", "FatJet_mass * FatJet_jecFactor")
+        // Keep FatJet_rawFactor self-consistent against the new pt/mass.
+        .Redefine("FatJet_rawFactor",
+                  [](RVec<float> rawFactor, RVec<float> factor) {
+                      RVec<float> out(rawFactor.size());
+                      for (size_t i = 0; i < rawFactor.size(); ++i) {
+                          out[i] = (factor[i] > 0.f)
+                                       ? 1.0f - (1.0f - rawFactor[i]) / factor[i]
+                                       : rawFactor[i];
+                      }
+                      return out;
+                  },
+                  {"FatJet_rawFactor", "FatJet_jecFactor"});
+}
+
+/*
+############################################
+JET ENERGY SCALE — uncertainty (up/down)
+############################################
+
+Applies a per-source JES uncertainty as a multiplicative shift on top of the nominal
+JEC. Run *after* applyJetEnergyCorrections. `JEC_source` is e.g. "Total",
+"Regrouped_Total", "Regrouped_FlavorQCD", etc. — see jet_jerc.json.gz for available keys.
+*/
+
+RNode applyJetEnergyScaleVariation(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
+                                   const std::unordered_map<std::string, std::string>& jec_prefix_map,
+                                   const std::unordered_map<std::string, std::string>& jec_suffix_map,
+                                   RNode df, std::string JEC_source, std::string variation) {
+    if (variation != "up" && variation != "down") return df;
+
+    const float sign = (variation == "up") ? +1.0f : -1.0f;
+
+    auto eval_unc = [cset_jerc, jec_prefix_map, jec_suffix_map, JEC_source, sign](
+            std::string year, RVec<float> pt, RVec<float> eta, RVec<float> var) {
+        if (var.empty()) return var;
+        auto cs_it = cset_jerc.find(year);
+        auto pf_it = jec_prefix_map.find(year);
+        auto sf_it = jec_suffix_map.find(year);
+        if (cs_it == cset_jerc.end() || pf_it == jec_prefix_map.end() || sf_it == jec_suffix_map.end()) {
+            return var;
+        }
+        const std::string unc_name = pf_it->second + "_" + JEC_source + "_" + sf_it->second;
+        std::shared_ptr<const correction::Correction> unc;
+        try {
+            unc = cs_it->second.at(unc_name);
+        } catch (const std::out_of_range&) {
+            static std::unordered_set<std::string> warned;
+            if (warned.insert(year + "/" + unc_name).second) {
+                std::cout << "Warning: JEC uncertainty source '" << unc_name
+                          << "' not found for year " << year << "." << std::endl;
+            }
+            return var;
+        }
+        RVec<float> out(var.size());
+        for (size_t i = 0; i < var.size(); ++i) {
+            float u = unc->evaluate({(double)eta[i], (double)pt[i]});
+            out[i] = var[i] * (1.0f + sign * u);
+        }
+        return out;
+    };
+
+    auto met_propagate_var = [](RVec<float> pt_old, RVec<float> pt_new, RVec<float> phi,
+                                RVec<float> neEmEF, RVec<float> chEmEF,
+                                float met_pt, float met_phi) {
+        double px = met_pt * std::cos(met_phi);
+        double py = met_pt * std::sin(met_phi);
+        for (size_t i = 0; i < pt_old.size(); ++i) {
+            if (pt_new[i] <= 15.0f) continue;
+            if ((neEmEF[i] + chEmEF[i]) > 0.9f) continue;
+            const double dpt = static_cast<double>(pt_old[i] - pt_new[i]);
+            px += dpt * std::cos(phi[i]);
+            py += dpt * std::sin(phi[i]);
+        }
+        return std::make_pair(static_cast<float>(std::sqrt(px*px + py*py)),
+                              static_cast<float>(std::atan2(py, px)));
+    };
+
+    return df
+        .Define("_Jet_pt_preJES", "Jet_pt")
+        .Redefine("Jet_pt",   eval_unc, {"year", "Jet_pt", "Jet_eta", "Jet_pt"})
+        .Redefine("Jet_mass", eval_unc, {"year", "Jet_pt", "Jet_eta", "Jet_mass"})
+        .Define("_jes_metProp", met_propagate_var,
+                {"_Jet_pt_preJES", "Jet_pt", "Jet_phi", "Jet_neEmEF", "Jet_chEmEF",
+                 "met_pt", "met_phi"})
+        .Redefine("met_pt",  "_jes_metProp.first")
+        .Redefine("met_phi", "_jes_metProp.second");
+}
+
+/*
+############################################
+JET ENERGY RESOLUTION — hybrid smearing (MC only)
+############################################
+
+Per AK4 jet (using the JEC-corrected pt that this function consumes):
+  res = PtResolution(eta, pt, rho)                        // relative resolution
+  sf  = ScaleFactor(eta, "nom"|"up"|"down")               // data/MC width ratio
+  pt_smear = JERSmear(pt, eta, gen_pt_or_-1, rho, event, res, sf)
+               // hybrid: scaling when |pt - pt_gen| < 3*res*pt and gen-matched (genJetIdx>=0),
+               // stochastic Gaussian otherwise. Always >= 0.
+  pt_new   = pt * pt_smear ; mass_new = mass * pt_smear
+
+Propagates the smearing to met_pt / met_phi via Type-I-style recipe.
+*/
+
+RNode applyJetEnergyResolution(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
+                               const std::unordered_map<std::string, correction::CorrectionSet>& cset_jer_smear,
+                               const std::unordered_map<std::string, std::string>& jer_res_map,
+                               const std::unordered_map<std::string, std::string>& jer_sf_map,
+                               RNode df, std::string variation) {
+
+    const std::string vary = (variation == "nominal") ? "nom" : variation;
+
+    auto compute_smear = [cset_jerc, cset_jer_smear, jer_res_map, jer_sf_map, vary](
+            std::string year,
+            RVec<float> pt, RVec<float> eta,
+            RVec<int> genJet_idx, RVec<float> genJet_pt,
+            float rho, unsigned long long event) {
+
+        RVec<float> factor(pt.size(), 1.0f);
+        if (pt.empty()) return factor;
+
+        auto cs_it = cset_jerc.find(year);
+        auto sm_it = cset_jer_smear.find("jer_smear");
+        auto rn_it = jer_res_map.find(year);
+        auto sn_it = jer_sf_map.find(year);
+        if (cs_it == cset_jerc.end() || sm_it == cset_jer_smear.end()
+            || rn_it == jer_res_map.end() || sn_it == jer_sf_map.end()) {
+            static std::unordered_set<std::string> warned;
+            if (warned.insert(year).second) {
+                std::cout << "Warning: JER inputs missing for year " << year
+                          << ". Skipping JER smearing." << std::endl;
+            }
+            return factor;
+        }
+
+        std::shared_ptr<const correction::Correction> res, sf, smear;
+        try {
+            res   = cs_it->second.at(rn_it->second);
+            sf    = cs_it->second.at(sn_it->second);
+            smear = sm_it->second.at("JERSmear");
+        } catch (const std::out_of_range&) {
+            static std::unordered_set<std::string> warned;
+            if (warned.insert(year).second) {
+                std::cout << "Warning: JER res/sf/smear key missing for year " << year
+                          << " (res=" << rn_it->second << " sf=" << sn_it->second
+                          << "). Skipping JER smearing." << std::endl;
+            }
+            return factor;
+        }
+
+        for (size_t i = 0; i < pt.size(); ++i) {
+            const float gen_pt = (genJet_idx[i] >= 0 && genJet_idx[i] < (int)genJet_pt.size())
+                                     ? genJet_pt[genJet_idx[i]] : -1.0f;
+            double r  = res->evaluate({(double)eta[i], (double)pt[i], (double)rho});
+            double s  = sf ->evaluate({(double)eta[i], vary});
+            double sm = smear->evaluate({(double)pt[i], (double)eta[i], (double)gen_pt,
+                                         (double)rho, (double)((int)event), r, s});
+            factor[i] = static_cast<float>(sm);
+        }
+        return factor;
+    };
+
+    auto met_propagate_jer = [](RVec<float> pt_pre, RVec<float> factor, RVec<float> phi,
+                                RVec<float> neEmEF, RVec<float> chEmEF,
+                                float met_pt, float met_phi) {
+        double px = met_pt * std::cos(met_phi);
+        double py = met_pt * std::sin(met_phi);
+        for (size_t i = 0; i < pt_pre.size(); ++i) {
+            const float pt_new = pt_pre[i] * factor[i];
+            if (pt_new <= 15.0f) continue;
+            if ((neEmEF[i] + chEmEF[i]) > 0.9f) continue;
+            const double dpt = static_cast<double>(pt_pre[i] - pt_new);
+            px += dpt * std::cos(phi[i]);
+            py += dpt * std::sin(phi[i]);
+        }
+        return std::make_pair(static_cast<float>(std::sqrt(px*px + py*py)),
+                              static_cast<float>(std::atan2(py, px)));
+    };
+
+    return df
+        .Define("Jet_jerFactor", compute_smear,
+                {"year", "Jet_pt", "Jet_eta", "Jet_genJetIdx", "GenJet_pt",
+                 "fixedGridRhoFastjetAll", "event"})
+        .Define("_Jet_pt_preJER", "Jet_pt")
+        .Define("_jer_metProp", met_propagate_jer,
+                {"_Jet_pt_preJER", "Jet_jerFactor", "Jet_phi",
+                 "Jet_neEmEF", "Jet_chEmEF", "met_pt", "met_phi"})
+        .Redefine("met_pt",   "_jer_metProp.first")
+        .Redefine("met_phi",  "_jer_metProp.second")
+        .Redefine("Jet_pt",   "Jet_pt   * Jet_jerFactor")
+        .Redefine("Jet_mass", "Jet_mass * Jet_jerFactor");
+}
+
+/*
+############################################
+FAT JET (AK8) ENERGY RESOLUTION — hybrid smearing (MC only)
+############################################
+
+Same recipe as AK4 but reading FatJet_* + GenJetAK8_* and the AK8PFPuppi resolution/SF
+keys. Does NOT propagate to MET.
+*/
+
+RNode applyFatJetEnergyResolution(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
+                                  const std::unordered_map<std::string, correction::CorrectionSet>& cset_jer_smear,
+                                  const std::unordered_map<std::string, std::string>& jer_res_map,
+                                  const std::unordered_map<std::string, std::string>& jer_sf_map,
+                                  RNode df, std::string variation) {
+
+    const std::string vary = (variation == "nominal") ? "nom" : variation;
+
+    auto compute_smear = [cset_jerc, cset_jer_smear, jer_res_map, jer_sf_map, vary](
+            std::string year,
+            RVec<float> pt, RVec<float> eta,
+            RVec<int> genJet_idx, RVec<float> genJet_pt,
+            float rho, unsigned long long event) {
+
+        RVec<float> factor(pt.size(), 1.0f);
+        if (pt.empty()) return factor;
+
+        auto cs_it = cset_jerc.find(year);
+        auto sm_it = cset_jer_smear.find("jer_smear");
+        auto rn_it = jer_res_map.find(year);
+        auto sn_it = jer_sf_map.find(year);
+        if (cs_it == cset_jerc.end() || sm_it == cset_jer_smear.end()
+            || rn_it == jer_res_map.end() || sn_it == jer_sf_map.end()) {
+            static std::unordered_set<std::string> warned;
+            if (warned.insert(year).second) {
+                std::cout << "Warning: AK8 JER inputs missing for year " << year
+                          << ". Skipping AK8 JER smearing." << std::endl;
+            }
+            return factor;
+        }
+
+        std::shared_ptr<const correction::Correction> res, sf, smear;
+        try {
+            res   = cs_it->second.at(rn_it->second);
+            sf    = cs_it->second.at(sn_it->second);
+            smear = sm_it->second.at("JERSmear");
+        } catch (const std::out_of_range&) {
+            static std::unordered_set<std::string> warned;
+            if (warned.insert(year).second) {
+                std::cout << "Warning: AK8 JER res/sf/smear key missing for year " << year
+                          << " (res=" << rn_it->second << " sf=" << sn_it->second
+                          << "). Skipping AK8 JER smearing." << std::endl;
+            }
+            return factor;
+        }
+
+        for (size_t i = 0; i < pt.size(); ++i) {
+            const float gen_pt = (genJet_idx[i] >= 0 && genJet_idx[i] < (int)genJet_pt.size())
+                                     ? genJet_pt[genJet_idx[i]] : -1.0f;
+            double r  = res->evaluate({(double)eta[i], (double)pt[i], (double)rho});
+            double s  = sf ->evaluate({(double)eta[i], vary});
+            double sm = smear->evaluate({(double)pt[i], (double)eta[i], (double)gen_pt,
+                                         (double)rho, (double)((int)event), r, s});
+            factor[i] = static_cast<float>(sm);
+        }
+        return factor;
+    };
+
+    return df
+        .Define("FatJet_jerFactor", compute_smear,
+                {"year", "FatJet_pt", "FatJet_eta", "FatJet_genJetAK8Idx", "GenJetAK8_pt",
+                 "fixedGridRhoFastjetAll", "event"})
+        .Redefine("FatJet_pt",   "FatJet_pt   * FatJet_jerFactor")
+        .Redefine("FatJet_mass", "FatJet_mass * FatJet_jerFactor");
 }
 
 /*
@@ -433,6 +826,16 @@ GENERAL CORRECTIONS
 
 RNode applyDataCorrections(RNode df_) {
     auto df = applyMETPhiCorrections(df_, true);
+    // Re-apply the latest JEC stack (raw recovery + L1*L2*L3*Residual compound).
+    // AK4 propagates to MET; AK8 does not (PuppiMET only includes AK4 Type-I).
+    df = applyJetEnergyCorrections(jetEnergyCorrections,
+                                   jetEnergyCorrections_JEC_prefix,
+                                   jetEnergyCorrections_JEC_suffix,
+                                   df, /*isData=*/true);
+    df = applyFatJetEnergyCorrections(fatJetEnergyCorrections,
+                                      fatJetEnergyCorrections_JEC_prefix,
+                                      fatJetEnergyCorrections_JEC_suffix,
+                                      df, /*isData=*/true);
     df = HEMCorrection(df, true);
     df = applyElectronScaleAndSmearing(df, true);
     return df;
@@ -440,6 +843,31 @@ RNode applyDataCorrections(RNode df_) {
 
 RNode applyMCCorrections(RNode df_) {
     auto df = applyMETPhiCorrections(df_, false);
+    // Nominal JEC for AK4 and AK8.
+    df = applyJetEnergyCorrections(jetEnergyCorrections,
+                                   jetEnergyCorrections_JEC_prefix,
+                                   jetEnergyCorrections_JEC_suffix,
+                                   df, /*isData=*/false);
+    df = applyFatJetEnergyCorrections(fatJetEnergyCorrections,
+                                      fatJetEnergyCorrections_JEC_prefix,
+                                      fatJetEnergyCorrections_JEC_suffix,
+                                      df, /*isData=*/false);
+    // JER smearing on top of JEC-corrected jets.
+    df = applyJetEnergyResolution(jetEnergyCorrections,
+                                  jetEnergyResolution_smear,
+                                  jetEnergyResolution_JER_res_name,
+                                  jetEnergyResolution_JER_sf_name,
+                                  df, /*variation=*/"nominal");
+    df = applyFatJetEnergyResolution(fatJetEnergyCorrections,
+                                     jetEnergyResolution_smear,
+                                     fatJetEnergyResolution_JER_res_name,
+                                     fatJetEnergyResolution_JER_sf_name,
+                                     df, /*variation=*/"nominal");
+    // JMS / JMR on FatJet_msoftdrop. Currently no-op: centrals are placeholders
+    // (shift = 0 GeV, factor = 1.0). Replace jetMassScale_central / jetMassResolution_central
+    // in corrections.h with the values derived from the per-analysis calibration fit.
+    df = applyJetMassScale(jetMassScale_central, df);
+    df = applyJetMassResolution(jetMassResolution_central, jetMassResolution_sigmaRel_central, df);
     df = HEMCorrection(df, false);
     df = applyElectronScaleAndSmearing(df, false);
     return df;

--- a/preselection/src/corrections.cpp
+++ b/preselection/src/corrections.cpp
@@ -425,32 +425,52 @@ RNode applyFatJetEnergyCorrections(const std::unordered_map<std::string, correct
 
 /*
 ############################################
-JET ENERGY SCALE — uncertainty (up/down)
+JET ENERGY SCALE — per-source uncertainties (up/down) into suffixed columns
 ############################################
 
-Applies a per-source JES uncertainty as a multiplicative shift on top of the nominal
-JEC. Run *after* applyJetEnergyCorrections. `JEC_source` is e.g. "Total",
-"Regrouped_Total", "Regrouped_FlavorQCD", etc. — see jet_jerc.json.gz for available keys.
+Per-source JES uncertainty applied as a multiplicative shift on top of the nominal JEC.
+Run *after* applyJetEnergyCorrections / applyFatJetEnergyCorrections. Each call writes
+one set of suffixed columns; the driver applyJESVariations loops over the 11 Regrouped V2
+sources × {Up, Dn} = 22 variations.
+
+  AK4: Jet_pt_<sfx>, Jet_mass_<sfx>, met_pt_<sfx>, met_phi_<sfx>   (Type-I MET propagated)
+  AK8: FatJet_pt_<sfx>, FatJet_mass_<sfx>                          (no MET propagation;
+                                                                    FatJet_msoftdrop has
+                                                                    its own JEC recipe)
+  <sfx> = "jes" + column_label + direction   e.g. "jesAbsoluteUp", "jesAbsoluteYearDn"
+
+Source list lives in kJESRegroupedSources below. Lookup keys in jet_jerc.json.gz are
+  <prefix>_<base_source>[_<year_token>]_<suffix>
+where year_token comes from jetEnergyCorrections_yearToken when the source is year-
+decorrelated (e.g. Regrouped_Absolute_2018 vs the year-correlated Regrouped_Absolute).
 */
 
-RNode applyJetEnergyScaleVariation(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
-                                   const std::unordered_map<std::string, std::string>& jec_prefix_map,
-                                   const std::unordered_map<std::string, std::string>& jec_suffix_map,
-                                   RNode df, std::string JEC_source, std::string variation) {
-    if (variation != "up" && variation != "down") return df;
-
-    const float sign = (variation == "up") ? +1.0f : -1.0f;
-
-    auto eval_unc = [cset_jerc, jec_prefix_map, jec_suffix_map, JEC_source, sign](
-            std::string year, RVec<float> pt, RVec<float> eta, RVec<float> var) {
-        if (var.empty()) return var;
+namespace {
+// Returns a closure giving per-jet shift factors (1 + sign*u) for use with RDF::Define.
+auto makeJESShiftEvaluator(
+        const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
+        const std::unordered_map<std::string, std::string>& jec_prefix_map,
+        const std::unordered_map<std::string, std::string>& jec_suffix_map,
+        const std::unordered_map<std::string, std::string>& year_token_map,
+        std::string base_source, bool yearDecorrelated, float sign) {
+    return [cset_jerc, jec_prefix_map, jec_suffix_map, year_token_map,
+            base_source, yearDecorrelated, sign](
+            std::string year, RVec<float> pt, RVec<float> eta) {
+        RVec<float> out(pt.size(), 1.0f);
+        if (pt.empty()) return out;
         auto cs_it = cset_jerc.find(year);
         auto pf_it = jec_prefix_map.find(year);
         auto sf_it = jec_suffix_map.find(year);
         if (cs_it == cset_jerc.end() || pf_it == jec_prefix_map.end() || sf_it == jec_suffix_map.end()) {
-            return var;
+            return out;
         }
-        const std::string unc_name = pf_it->second + "_" + JEC_source + "_" + sf_it->second;
+        std::string src = base_source;
+        if (yearDecorrelated) {
+            auto yt_it = year_token_map.find(year);
+            if (yt_it == year_token_map.end()) return out;
+            src += "_" + yt_it->second;
+        }
+        const std::string unc_name = pf_it->second + "_" + src + "_" + sf_it->second;
         std::shared_ptr<const correction::Correction> unc;
         try {
             unc = cs_it->second.at(unc_name);
@@ -460,19 +480,22 @@ RNode applyJetEnergyScaleVariation(const std::unordered_map<std::string, correct
                 std::cout << "Warning: JEC uncertainty source '" << unc_name
                           << "' not found for year " << year << "." << std::endl;
             }
-            return var;
+            return out;
         }
-        RVec<float> out(var.size());
-        for (size_t i = 0; i < var.size(); ++i) {
+        for (size_t i = 0; i < pt.size(); ++i) {
             float u = unc->evaluate({(double)eta[i], (double)pt[i]});
-            out[i] = var[i] * (1.0f + sign * u);
+            out[i] = 1.0f + sign * u;
         }
         return out;
     };
+}
 
-    auto met_propagate_var = [](RVec<float> pt_old, RVec<float> pt_new, RVec<float> phi,
-                                RVec<float> neEmEF, RVec<float> chEmEF,
-                                float met_pt, float met_phi) {
+// Type-I-style MET shift: rebuilds (met_pt, met_phi) from (pt_old - pt_new) per AK4 jet,
+// applying the standard >15 GeV / emf<0.9 filter.
+auto jesMetPropagator() {
+    return [](RVec<float> pt_old, RVec<float> pt_new, RVec<float> phi,
+              RVec<float> neEmEF, RVec<float> chEmEF,
+              float met_pt, float met_phi) {
         double px = met_pt * std::cos(met_phi);
         double py = met_pt * std::sin(met_phi);
         for (size_t i = 0; i < pt_old.size(); ++i) {
@@ -485,16 +508,113 @@ RNode applyJetEnergyScaleVariation(const std::unordered_map<std::string, correct
         return std::make_pair(static_cast<float>(std::sqrt(px*px + py*py)),
                               static_cast<float>(std::atan2(py, px)));
     };
+}
+} // anonymous namespace
+
+RNode defineAK4JESVariation(
+        const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
+        const std::unordered_map<std::string, std::string>& jec_prefix_map,
+        const std::unordered_map<std::string, std::string>& jec_suffix_map,
+        const std::unordered_map<std::string, std::string>& year_token_map,
+        RNode df, const std::string& column_label, const std::string& base_source,
+        bool yearDecorrelated, const std::string& direction) {
+    if (direction != "Up" && direction != "Dn") return df;
+    const float sign = (direction == "Up") ? +1.0f : -1.0f;
+    const std::string sfx = "jes" + column_label + direction;
+    const std::string shiftCol = "_Jet_shift_" + sfx;
+    const std::string metPropCol = "_metProp_" + sfx;
+
+    auto eval_factor = makeJESShiftEvaluator(cset_jerc, jec_prefix_map, jec_suffix_map,
+                                             year_token_map, base_source, yearDecorrelated, sign);
+    auto met_prop = jesMetPropagator();
 
     return df
-        .Define("_Jet_pt_preJES", "Jet_pt")
-        .Redefine("Jet_pt",   eval_unc, {"year", "Jet_pt", "Jet_eta", "Jet_pt"})
-        .Redefine("Jet_mass", eval_unc, {"year", "Jet_pt", "Jet_eta", "Jet_mass"})
-        .Define("_jes_metProp", met_propagate_var,
-                {"_Jet_pt_preJES", "Jet_pt", "Jet_phi", "Jet_neEmEF", "Jet_chEmEF",
+        .Define(shiftCol, eval_factor, {"year", "Jet_pt", "Jet_eta"})
+        .Define("Jet_pt_"   + sfx, "Jet_pt   * " + shiftCol)
+        .Define("Jet_mass_" + sfx, "Jet_mass * " + shiftCol)
+        .Define(metPropCol, met_prop,
+                {"Jet_pt", "Jet_pt_" + sfx, "Jet_phi", "Jet_neEmEF", "Jet_chEmEF",
                  "met_pt", "met_phi"})
-        .Redefine("met_pt",  "_jes_metProp.first")
-        .Redefine("met_phi", "_jes_metProp.second");
+        .Define("met_pt_"  + sfx, [](std::pair<float,float> p){ return p.first;  }, {metPropCol})
+        .Define("met_phi_" + sfx, [](std::pair<float,float> p){ return p.second; }, {metPropCol});
+}
+
+RNode defineFatJetJESVariation(
+        const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
+        const std::unordered_map<std::string, std::string>& jec_prefix_map,
+        const std::unordered_map<std::string, std::string>& jec_suffix_map,
+        const std::unordered_map<std::string, std::string>& year_token_map,
+        RNode df, const std::string& column_label, const std::string& base_source,
+        bool yearDecorrelated, const std::string& direction) {
+    if (direction != "Up" && direction != "Dn") return df;
+    const float sign = (direction == "Up") ? +1.0f : -1.0f;
+    const std::string sfx = "jes" + column_label + direction;
+    const std::string shiftCol = "_FatJet_shift_" + sfx;
+
+    auto eval_factor = makeJESShiftEvaluator(cset_jerc, jec_prefix_map, jec_suffix_map,
+                                             year_token_map, base_source, yearDecorrelated, sign);
+
+    return df
+        .Define(shiftCol, eval_factor, {"year", "FatJet_pt", "FatJet_eta"})
+        .Define("FatJet_pt_"   + sfx, "FatJet_pt   * " + shiftCol)
+        .Define("FatJet_mass_" + sfx, "FatJet_mass * " + shiftCol);
+}
+
+namespace {
+struct JESSourceSpec {
+    const char* label;          // column-name suffix, e.g. "Absolute" or "AbsoluteYear"
+    const char* base_source;    // JEC source key root, e.g. "Regrouped_Absolute"
+    bool yearDecorrelated;      // append _<year_token> at lookup time?
+};
+
+// 11 Regrouped V2 sources — confirmed against jet_jerc.json.gz / fatJet_jerc.json.gz
+// for all 9 campaigns on 2026-05-14. JME-POG standard set; combine treats the *_Year
+// entries as uncorrelated across years (handled downstream via the `year` hist axis).
+static const std::vector<JESSourceSpec> kJESRegroupedSources = {
+    {"Absolute",            "Regrouped_Absolute",       false},
+    {"BBEC1",               "Regrouped_BBEC1",          false},
+    {"EC2",                 "Regrouped_EC2",            false},
+    {"HF",                  "Regrouped_HF",             false},
+    {"RelativeBal",         "Regrouped_RelativeBal",    false},
+    {"FlavorQCD",           "Regrouped_FlavorQCD",      false},
+    {"AbsoluteYear",        "Regrouped_Absolute",       true},
+    {"BBEC1Year",           "Regrouped_BBEC1",          true},
+    {"EC2Year",             "Regrouped_EC2",            true},
+    {"HFYear",              "Regrouped_HF",             true},
+    {"RelativeSampleYear",  "Regrouped_RelativeSample", true},
+};
+static const std::array<const char*, 2> kJESDirections = {"Up", "Dn"};
+} // anonymous namespace
+
+RNode applyJESVariations(RNode df) {
+    for (const auto& src : kJESRegroupedSources) {
+        for (const char* dir : kJESDirections) {
+            df = defineAK4JESVariation(
+                jetEnergyCorrections,
+                jetEnergyCorrections_JEC_prefix,
+                jetEnergyCorrections_JEC_suffix,
+                jetEnergyCorrections_yearToken,
+                df, src.label, src.base_source, src.yearDecorrelated, dir);
+            df = defineFatJetJESVariation(
+                fatJetEnergyCorrections,
+                fatJetEnergyCorrections_JEC_prefix,
+                fatJetEnergyCorrections_JEC_suffix,
+                jetEnergyCorrections_yearToken,
+                df, src.label, src.base_source, src.yearDecorrelated, dir);
+        }
+    }
+    return df;
+}
+
+std::vector<std::string> jesVariationSuffixes() {
+    std::vector<std::string> out;
+    out.reserve(kJESRegroupedSources.size() * kJESDirections.size());
+    for (const auto& src : kJESRegroupedSources) {
+        for (const char* dir : kJESDirections) {
+            out.push_back(std::string("jes") + src.label + dir);
+        }
+    }
+    return out;
 }
 
 /*
@@ -863,6 +983,9 @@ RNode applyMCCorrections(RNode df_) {
                                      fatJetEnergyResolution_JER_res_name,
                                      fatJetEnergyResolution_JER_sf_name,
                                      df, /*variation=*/"nominal");
+    // JES uncertainties — 11 Regrouped V2 sources × {Up, Dn} as suffixed branches.
+    // Must run after the nominal JEC+JER so the shift sits on top of the corrected baseline.
+    df = applyJESVariations(df);
     // JMS / JMR on FatJet_msoftdrop. Currently no-op: centrals are placeholders
     // (shift = 0 GeV, factor = 1.0). Replace jetMassScale_central / jetMassResolution_central
     // in corrections.h with the values derived from the per-analysis calibration fit.

--- a/preselection/src/corrections.cpp
+++ b/preselection/src/corrections.cpp
@@ -1,5 +1,9 @@
 #include "corrections.h"
 
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
 /*
 ############################################
 B-TAGGING WORKING POINTS
@@ -20,86 +24,92 @@ RVec<bool> isbTagTight(std::string year, RVec<float> btag_score) {
 
 /*
 ############################################
-JET MASS SCALE (JMS) AND RESOLUTION (JMR)
+JET MASS SCALE (JMS) AND RESOLUTION (JMR) — generic, per-mass-column
 ############################################
 
-Parametrization is applied on `FatJet_msoftdrop`:
+Column-agnostic helpers: pass the target mass branch (and, for JMR, the gen
+reference mass + gen-index columns) as arguments so the same code serves
+`FatJet_msoftdrop`, the GloParT regressed mass, or any other analysis mass
+variable.
 
-  JMS  : msd' = max(0, msd + Δshift[year])               // additive shift in GeV
-  JMR  : matched   →  msd' = max(0, m_gen + f * (msd - m_gen))   
-         unmatched →  msd' = max(0, msd * (1 + √max(f²-1,0) * σrel * N(0,1)))
-                      // σrel = 1.0 is a placeholder; replace with the per-era msd
-                      // resolution when JMR is derived. Branch is dead while f == 1.0.
+  JMS  : m' = max(0, m + Δshift[year])                   // additive shift in GeV
+  JMR  : matched   →  m' = max(0, m_gen + f * (m - m_gen))
+         unmatched →  m' = max(0, m * (1 + √max(f²-1,0) * σrel[year] * N(0,1)))
 
-Current factors are placeholders (Δshift = 0 GeV and f = 1.0), both reduce to the identity.
-Replace with the calibration outputs once derived. 
-TO DO: add systematic up/down, add a `variation` argument and pass ±1σ shift/scale instead of the central.
+Choice of gen reference `m_gen` matters for GloParT: use whatever the network
+was regressed to (parton W/Z/H mass or particle-level jet mass). For msd, the
+POG-standard proxy is `GenJetAK8_mass[FatJet_genJetAK8Idx]`.
 
+Currently unwired — this analysis calibrates JMS/JMR on the GloParT mass, not
+on msd (§ 5-6 of CORRECTIONS.md), and the GloParT calibration hasn't been
+derived yet. When it lands, wire the calls into `applyMCCorrections` with the
+GloParT column names + per-era shift/factor/σ_rel maps from the calibration
+fit. Up/down systematic variants add a `variation` arg carrying the ±1σ
+shift/scale.
 */
 
-RNode applyJetMassScale(const std::unordered_map<std::string, float>& jms_shift, RNode df) {
-    auto eval = [jms_shift](std::string year, RVec<float> msd) {
-        auto it = jms_shift.find(year);
-        if (it == jms_shift.end()) {
-            static std::unordered_set<std::string> warned_years;
-            if (warned_years.insert(year).second) {
-                std::cout << "Warning: JMS shift not defined for year " << year
-                          << ". Skipping." << std::endl;
+RNode applyJetMassScale(const std::unordered_map<std::string, float>& shift_map,
+                     const std::string& mass_col,
+                     RNode df) {
+    auto eval = [shift_map, mass_col](std::string year, RVec<float> m) {
+        auto it = shift_map.find(year);
+        if (it == shift_map.end()) {
+            static std::unordered_set<std::string> warned;
+            if (warned.insert(mass_col + "/" + year).second) {
+                std::cout << "Warning: mass-scale shift not defined for year " << year
+                          << " on column " << mass_col << ". Skipping." << std::endl;
             }
-            return msd;
+            return m;
         }
         const float shift = it->second;
-        if (shift == 0.0f || msd.empty()) return msd;
-        // apply jet mass cale shift to every fat jet's soft-drop mass in the event
-        for (auto& m : msd) m = std::max(0.0f, m + shift);
-        return msd;
+        if (shift == 0.0f || m.empty()) return m;
+        for (auto& x : m) x = std::max(0.0f, x + shift);
+        return m;
     };
-    return df.Redefine("FatJet_msoftdrop", eval, {"year", "FatJet_msoftdrop"});
+    return df.Redefine(mass_col, eval, {"year", mass_col});
 }
 
-RNode applyJetMassResolution(const std::unordered_map<std::string, float>& jmr_factor,
-                             const std::unordered_map<std::string, float>& jmr_sigma_rel,
-                             RNode df) {
-    auto eval = [jmr_factor, jmr_sigma_rel](std::string year,
-                             RVec<float> msd,
-                             RVec<short> genJet_idx, RVec<float> genJet_mass,
+RNode applyJetMassResolution(const std::unordered_map<std::string, float>& factor_map,
+                          const std::unordered_map<std::string, float>& sigma_rel_map,
+                          const std::string& mass_col,
+                          const std::string& gen_mass_col,
+                          const std::string& gen_idx_col,
+                          RNode df) {
+    auto eval = [factor_map, sigma_rel_map, mass_col](std::string year,
+                             RVec<float> m,
+                             RVec<short> gen_idx, RVec<float> gen_mass,
                              unsigned int lumi, unsigned long long event) {
-        auto it = jmr_factor.find(year);
-        if (it == jmr_factor.end()) {
-            static std::unordered_set<std::string> warned_years;
-            if (warned_years.insert(year).second) {
-                std::cout << "Warning: JMR factor not defined for year " << year
-                          << ". Skipping." << std::endl;
+        auto it = factor_map.find(year);
+        if (it == factor_map.end()) {
+            static std::unordered_set<std::string> warned;
+            if (warned.insert(mass_col + "/" + year).second) {
+                std::cout << "Warning: mass-resolution factor not defined for year " << year
+                          << " on column " << mass_col << ". Skipping." << std::endl;
             }
-            return msd;
+            return m;
         }
         const float f = it->second;
-        if (f == 1.0f || msd.empty()) return msd;
+        if (f == 1.0f || m.empty()) return m;
 
         const float widen = std::sqrt(std::max(f * f - 1.0f, 0.0f));
-        // sigma_rel = relative msoftdrop resolution σ(msd)/msd, used by the unmatched
-        // stochastic branch. Per-era placeholder maps jetMassResolution_sigmaRel_central
-        // in corrections.h; replace with the value from the same calibration fit as
-        // jmr_factor. Falls back to 1.0 if the year is missing from the map.
-        auto sr_it = jmr_sigma_rel.find(year);
-        const float sigma_rel = (sr_it != jmr_sigma_rel.end()) ? sr_it->second : 1.0f;
+        auto sr_it = sigma_rel_map.find(year);
+        const float sigma_rel = (sr_it != sigma_rel_map.end()) ? sr_it->second : 1.0f;
         TRandom3 rng((static_cast<unsigned long long>(lumi) << 10) ^ event);
-        for (size_t i = 0; i < msd.size(); ++i) {
-            const bool matched = (genJet_idx[i] >= 0
-                                  && genJet_idx[i] < static_cast<int>(genJet_mass.size()));
+        for (size_t i = 0; i < m.size(); ++i) {
+            const bool matched = (gen_idx[i] >= 0
+                                  && gen_idx[i] < static_cast<int>(gen_mass.size()));
             if (matched) {
-                const float m_gen = genJet_mass[genJet_idx[i]];
-                msd[i] = std::max(0.0f, m_gen + f * (msd[i] - m_gen));
+                const float m_gen = gen_mass[gen_idx[i]];
+                m[i] = std::max(0.0f, m_gen + f * (m[i] - m_gen));
             } else {
                 const float kick = static_cast<float>(rng.Gaus(0.0, 1.0));
-                msd[i] = std::max(0.0f, msd[i] * (1.0f + widen * sigma_rel * kick));
+                m[i] = std::max(0.0f, m[i] * (1.0f + widen * sigma_rel * kick));
             }
         }
-        return msd;
+        return m;
     };
-    return df.Redefine("FatJet_msoftdrop", eval,
-                       {"year", "FatJet_msoftdrop",
-                        "FatJet_genJetAK8Idx", "GenJetAK8_mass",
+    return df.Redefine(mass_col, eval,
+                       {"year", mass_col, gen_idx_col, gen_mass_col,
                         "luminosityBlock", "event"});
 }
 
@@ -160,9 +170,12 @@ RNode applyMETPhiCorrections(RNode df, bool isData) {
         
         return std::make_pair(static_cast<float>(pt_corr), static_cast<float>(phi_corr));
     };
-    return df.Define("_MET_phicorr", eval_correction, {"year", "PuppiMET_pt", "PuppiMET_phi", "PV_npvs", "run"})
-            .Define("met_pt", "_MET_phicorr.first")            
-            .Define("met_phi", "_MET_phicorr.second");
+    // Runs AFTER applyType1MET, so it refines the already-rebuilt (met_pt, met_phi) rather than
+    // starting from PuppiMET. Run 3 has no met.json configured (see corrections.h) → no-op there;
+    // the φ correction currently only touches the nominal MET, not the JES-varied copies.
+    return df.Define("_MET_phicorr", eval_correction, {"year", "met_pt", "met_phi", "PV_npvs", "run"})
+            .Redefine("met_pt",  "_MET_phicorr.first")
+            .Redefine("met_phi", "_MET_phicorr.second");
 }
 
 /*
@@ -195,20 +208,20 @@ Recipe (per AK4 jet, year-aware):
   pt_raw   = (1 - Jet_rawFactor) * Jet_pt     // undo NanoAOD JEC
   mass_raw = (1 - Jet_rawFactor) * Jet_mass
 
-  factor   = compound(Jet_area, Jet_eta, pt_raw, rho [, run])
+  factor   = compound(Jet_area, Jet_eta, pt_raw, rho [, Jet_phi] [, run])
              // compound = L1FastJet * L2Relative * L3Absolute (* L2L3Residual for DATA),
              // with `inputs_update=[JetPt]` so each stage feeds the next its updated pt.
+             // The 2023BPix + 2024 pinned files also require Jet_phi; evalJECCompound()
+             // appends JetPhi/run only when the file declares them (see below).
   pt_new   = pt_raw   * factor
   mass_new = mass_raw * factor
 
-Type-I MET is rebuilt on top of the NanoAOD baseline:
-  met_x_new = met_x_old + sum_jets (pt_NanoAOD - pt_new) * cos(phi)
-  met_y_new = met_y_old + sum_jets (pt_NanoAOD - pt_new) * sin(phi)
-where the sum runs over jets with pt_new > 15 GeV and (neEmEF + chEmEF) < 0.9.
-FIXME: this needs to be updated to the new recommendation: https://indico.cern.ch/event/1644923/contributions/6916115/attachments/3211593/5720863/260202_JMEGeneral_Type1METWithNano_Nurfikri.pdf
+MET is NOT touched here anymore. Type-I MET is rebuilt from RawPuppiMET in applyType1MET()
+(over Jet + CorrT1METJet, with muon subtraction), following the JERC recipe in
+Type1MET.pdf / skimmer getT1CHSMET. See the TYPE-1 PUPPI MET section below.
 
 NanoAOD branches consumed:
-  Jet_pt, Jet_mass, Jet_eta, Jet_phi, Jet_area, Jet_rawFactor, Jet_neEmEF, Jet_chEmEF,
+  Jet_pt, Jet_mass, Jet_eta, Jet_phi, Jet_area, Jet_rawFactor,
   Rho_fixedGridRhoFastjetAll, run, year
 */
 
@@ -226,6 +239,52 @@ namespace {
         }
         return base + (isData ? "_DATA" : "_MC") + "_L1L2L3Res_" + algo;
     }
+
+    // Evaluate a JEC L1L2L3Res compound, building the input vector in the exact order the
+    // file declares it. The pinned 2026-06-05 files added a `JetPhi` input to the
+    // 2023BPix + 2024 compounds (and DATA additionally takes `run`); older eras do not have
+    // it. Querying inputs() keeps a single call correct for every era and future file bumps —
+    // passing a fixed-length arg list silently threw "wrong number of inputs" for 2023BPix/2024,
+    // which the per-jet catch turned into sf=1.0 (jets left at raw pT).
+    inline double evalJECCompound(const correction::CompoundCorrection& comp,
+                                  double area, double eta, double pt, double rho,
+                                  double phi, double run) {
+        std::vector<correction::Variable::Type> args;
+        args.reserve(comp.inputs().size());
+        for (const auto& v : comp.inputs()) {
+            const std::string n = v.name();
+            if      (n == "JetA")   args.push_back(area);
+            else if (n == "JetEta") args.push_back(eta);
+            else if (n == "JetPt")  args.push_back(pt);
+            else if (n == "Rho")    args.push_back(rho);
+            else if (n == "JetPhi") args.push_back(phi);
+            else if (n == "run")    args.push_back(run);
+            else throw std::runtime_error("JEC compound: unexpected input '" + n
+                                          + "'. corrections.cpp evalJECCompound needs a mapping for it.");
+        }
+        return comp.evaluate(args);
+    }
+
+    // Evaluate a JER PtResolution / ScaleFactor correction by input name. The pinned
+    // 2026-06-05 files ship the ScaleFactor with inputs [JetEta, JetPt] and NO `systematic`
+    // string (older files had one). The previous size>=3 heuristic mistook that for
+    // [JetEta, systematic] and fed "nom" into the JetPt slot ("wrong type: got string").
+    // `syst` is only used when the correction actually declares a `systematic` input.
+    inline double evalJERCorrection(const correction::Correction& c,
+                                    double eta, double pt, double rho, const std::string& syst) {
+        std::vector<correction::Variable::Type> args;
+        args.reserve(c.inputs().size());
+        for (const auto& v : c.inputs()) {
+            const std::string n = v.name();
+            if      (n == "JetEta")     args.push_back(eta);
+            else if (n == "JetPt")      args.push_back(pt);
+            else if (n == "Rho")        args.push_back(rho);
+            else if (n == "systematic") args.push_back(syst);
+            else throw std::runtime_error("JER correction '" + c.name() + "': unexpected input '" + n
+                                          + "'. corrections.cpp evalJERCorrection needs a mapping for it.");
+        }
+        return c.evaluate(args);
+    }
 }
 
 RNode applyJetEnergyCorrections(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
@@ -235,7 +294,7 @@ RNode applyJetEnergyCorrections(const std::unordered_map<std::string, correction
 
     auto compute_factor = [cset_jerc, jec_prefix_map, jec_suffix_map, isData](
             std::string year,
-            RVec<float> pt, RVec<float> eta, RVec<float> area, RVec<float> rawFactor,
+            RVec<float> pt, RVec<float> eta, RVec<float> phi, RVec<float> area, RVec<float> rawFactor,
             float rho, unsigned int run) {
 
         RVec<float> factor(pt.size(), 1.0f);
@@ -245,12 +304,9 @@ RNode applyJetEnergyCorrections(const std::unordered_map<std::string, correction
         auto pf_it = jec_prefix_map.find(year);
         auto sf_it = jec_suffix_map.find(year);
         if (cs_it == cset_jerc.end() || pf_it == jec_prefix_map.end() || sf_it == jec_suffix_map.end()) {
-            static std::unordered_set<std::string> warned_years;
-            if (warned_years.insert(year).second) {
-                std::cout << "Warning: JEC inputs missing for year " << year
-                          << ". Skipping nominal JEC re-application." << std::endl;
-            }
-            return factor;
+            throw std::runtime_error("AK4 JEC: no correction set / prefix / suffix configured for year '"
+                                     + year + "'. Refusing to run with jets uncorrected — add this year to "
+                                       "the JEC maps in corrections.h.");
         }
 
         const std::string compound_name = makeCompoundJECName(pf_it->second, sf_it->second, isData);
@@ -258,28 +314,22 @@ RNode applyJetEnergyCorrections(const std::unordered_map<std::string, correction
         try {
             compound = cs_it->second.compound().at(compound_name);
         } catch (const std::out_of_range&) {
-            static std::unordered_set<std::string> warned_keys;
-            if (warned_keys.insert(year + "/" + compound_name).second) {
-                std::cout << "Warning: compound JEC '" << compound_name
-                          << "' not found for year " << year
-                          << ". Skipping nominal JEC re-application." << std::endl;
-            }
-            return factor;
+            throw std::runtime_error("AK4 JEC: compound '" + compound_name
+                                     + "' not found in the pinned jet_jerc.json.gz for year '" + year
+                                     + "'. The JEC tag string in corrections.h is stale relative to the "
+                                       "pinned snapshot (version drift). Refusing to run with jets uncorrected.");
         }
 
         for (size_t i = 0; i < pt.size(); ++i) {
             float pt_raw = (1.0f - rawFactor[i]) * pt[i];
             double sf = 1.0;
             try {
-                if (isData) {
-                    sf = compound->evaluate({(double)area[i], (double)eta[i],
-                                             (double)pt_raw,  (double)rho,
-                                             (double)run});
-                } else {
-                    sf = compound->evaluate({(double)area[i], (double)eta[i],
-                                             (double)pt_raw,  (double)rho});
-                }
+                // evalJECCompound appends JetPhi / run only when the pinned file declares them.
+                sf = evalJECCompound(*compound, (double)area[i], (double)eta[i], (double)pt_raw,
+                                     (double)rho, (double)phi[i], (double)run);
             } catch (const std::exception& e) {
+                std::cout << "Warning: JEC evaluation failed for jet " << i << " (pt_raw=" << pt_raw
+                          << ", eta=" << eta[i] << "): " << e.what() << ". Setting SF to 1.0." << std::endl;
                 sf = 1.0;
             }
             // Multiplicative factor on the *NanoAOD* pt: Jet_pt_new = Jet_pt * factor
@@ -289,34 +339,13 @@ RNode applyJetEnergyCorrections(const std::unordered_map<std::string, correction
         return factor;
     };
 
-    auto met_propagate = [](RVec<float> pt_old, RVec<float> phi,
-                            RVec<float> factor, RVec<float> neEmEF, RVec<float> chEmEF,
-                            float met_pt, float met_phi) {
-        // Type-I MET propagation: replace the contribution of NanoAOD-corrected jets
-        // (pt_old) with re-corrected jets (pt_new = pt_old * factor) in the MET sum.
-        double px = met_pt * std::cos(met_phi);
-        double py = met_pt * std::sin(met_phi);
-        for (size_t i = 0; i < pt_old.size(); ++i) {
-            const float pt_new = pt_old[i] * factor[i];
-            if (pt_new <= 15.0f) continue;                       // Type-I threshold
-            if ((neEmEF[i] + chEmEF[i]) > 0.9f) continue;        // EM-fraction veto
-            const double dpt = static_cast<double>(pt_old[i] - pt_new);
-            px += dpt * std::cos(phi[i]);
-            py += dpt * std::sin(phi[i]);
-        }
-        return std::make_pair(static_cast<float>(std::sqrt(px*px + py*py)),
-                              static_cast<float>(std::atan2(py, px)));
-    };
-
+    // NOTE: Type-I MET is no longer propagated here. It is rebuilt from scratch in
+    // applyType1MET() (from RawPuppiMET, over Jet + CorrT1METJet, with muon subtraction),
+    // which runs after all jet corrections. This function only re-calibrates the jets.
     return df
         .Define("Jet_jecFactor", compute_factor,
-                {"year", "Jet_pt", "Jet_eta", "Jet_area", "Jet_rawFactor",
+                {"year", "Jet_pt", "Jet_eta", "Jet_phi", "Jet_area", "Jet_rawFactor",
                  "Rho_fixedGridRhoFastjetAll", "run"})
-        .Define("_jec_metProp", met_propagate,
-                {"Jet_pt", "Jet_phi", "Jet_jecFactor",
-                 "Jet_neEmEF", "Jet_chEmEF", "met_pt", "met_phi"})
-        .Redefine("met_pt",   "_jec_metProp.first")
-        .Redefine("met_phi",  "_jec_metProp.second")
         .Redefine("Jet_pt",   "Jet_pt   * Jet_jecFactor")
         .Redefine("Jet_mass", "Jet_mass * Jet_jecFactor")
         // Reset rawFactor so downstream callers see a self-consistent (pt, mass, rawFactor) triple.
@@ -351,7 +380,7 @@ RNode applyFatJetEnergyCorrections(const std::unordered_map<std::string, correct
 
     auto compute_factor = [cset_jerc, jec_prefix_map, jec_suffix_map, isData](
             std::string year,
-            RVec<float> pt, RVec<float> eta, RVec<float> area, RVec<float> rawFactor,
+            RVec<float> pt, RVec<float> eta, RVec<float> phi, RVec<float> area, RVec<float> rawFactor,
             float rho, unsigned int run) {
 
         RVec<float> factor(pt.size(), 1.0f);
@@ -361,12 +390,9 @@ RNode applyFatJetEnergyCorrections(const std::unordered_map<std::string, correct
         auto pf_it = jec_prefix_map.find(year);
         auto sf_it = jec_suffix_map.find(year);
         if (cs_it == cset_jerc.end() || pf_it == jec_prefix_map.end() || sf_it == jec_suffix_map.end()) {
-            static std::unordered_set<std::string> warned_years;
-            if (warned_years.insert(year).second) {
-                std::cout << "Warning: AK8 JEC inputs missing for year " << year
-                          << ". Skipping nominal AK8 JEC re-application." << std::endl;
-            }
-            return factor;
+            throw std::runtime_error("AK8 JEC: no correction set / prefix / suffix configured for year '"
+                                     + year + "'. Refusing to run with fat jets uncorrected — add this year "
+                                       "to the JEC maps in corrections.h.");
         }
 
         const std::string compound_name = makeCompoundJECName(pf_it->second, sf_it->second, isData);
@@ -374,28 +400,21 @@ RNode applyFatJetEnergyCorrections(const std::unordered_map<std::string, correct
         try {
             compound = cs_it->second.compound().at(compound_name);
         } catch (const std::out_of_range&) {
-            static std::unordered_set<std::string> warned_keys;
-            if (warned_keys.insert(year + "/" + compound_name).second) {
-                std::cout << "Warning: AK8 compound JEC '" << compound_name
-                          << "' not found for year " << year
-                          << ". Skipping nominal AK8 JEC re-application." << std::endl;
-            }
-            return factor;
+            throw std::runtime_error("AK8 JEC: compound '" + compound_name
+                                     + "' not found in the pinned fatJet_jerc.json.gz for year '" + year
+                                     + "'. The JEC tag string in corrections.h is stale relative to the "
+                                       "pinned snapshot (version drift). Refusing to run with fat jets uncorrected.");
         }
 
         for (size_t i = 0; i < pt.size(); ++i) {
             float pt_raw = (1.0f - rawFactor[i]) * pt[i];
             double sf = 1.0;
             try {
-                if (isData) {
-                    sf = compound->evaluate({(double)area[i], (double)eta[i],
-                                             (double)pt_raw,  (double)rho,
-                                             (double)run});
-                } else {
-                    sf = compound->evaluate({(double)area[i], (double)eta[i],
-                                             (double)pt_raw,  (double)rho});
-                }
-            } catch (const std::exception&) {
+                sf = evalJECCompound(*compound, (double)area[i], (double)eta[i], (double)pt_raw,
+                                     (double)rho, (double)phi[i], (double)run);
+            } catch (const std::exception& e) {
+                std::cout << "Warning: JEC evaluation failed for fat jet " << i << " (pt_raw=" << pt_raw
+                          << ", eta=" << eta[i] << "): " << e.what() << ". Setting SF to 1.0." << std::endl;
                 sf = 1.0;
             }
             factor[i] = (1.0f - rawFactor[i]) * static_cast<float>(sf);
@@ -405,7 +424,7 @@ RNode applyFatJetEnergyCorrections(const std::unordered_map<std::string, correct
 
     return df
         .Define("FatJet_jecFactor", compute_factor,
-                {"year", "FatJet_pt", "FatJet_eta", "FatJet_area", "FatJet_rawFactor",
+                {"year", "FatJet_pt", "FatJet_eta", "FatJet_phi", "FatJet_area", "FatJet_rawFactor",
                  "Rho_fixedGridRhoFastjetAll", "run"})
         .Redefine("FatJet_pt",   "FatJet_pt   * FatJet_jecFactor")
         .Redefine("FatJet_mass", "FatJet_mass * FatJet_jecFactor")
@@ -433,10 +452,10 @@ Run *after* applyJetEnergyCorrections / applyFatJetEnergyCorrections. Each call 
 one set of suffixed columns; the driver applyJESVariations loops over the 11 Regrouped V2
 sources × {Up, Dn} = 22 variations.
 
-  AK4: Jet_pt_<sfx>, Jet_mass_<sfx>, met_pt_<sfx>, met_phi_<sfx>   (Type-I MET propagated)
-  AK8: FatJet_pt_<sfx>, FatJet_mass_<sfx>                          (no MET propagation;
-                                                                    FatJet_msoftdrop has
-                                                                    its own JEC recipe)
+  AK4: Jet_pt_<sfx>, Jet_mass_<sfx>, _Jet_shift_<sfx>   (per-jet shift; MET built in applyType1MET)
+  AK8: FatJet_pt_<sfx>, FatJet_mass_<sfx>               (FatJet_msoftdrop has its own JEC recipe)
+  The matching met_pt_<sfx> / met_phi_<sfx> are produced by applyType1MET, which reads
+  _Jet_shift_<sfx> and rebuilds the Type-I MET from RawPuppiMET for that variation.
   <sfx> = "jes" + column_label + direction   e.g. "jesAbsoluteUp", "jesAbsoluteYearDn"
 
 Source list lives in kJESRegroupedSources below. Lookup keys in jet_jerc.json.gz are
@@ -462,12 +481,18 @@ auto makeJESShiftEvaluator(
         auto pf_it = jec_prefix_map.find(year);
         auto sf_it = jec_suffix_map.find(year);
         if (cs_it == cset_jerc.end() || pf_it == jec_prefix_map.end() || sf_it == jec_suffix_map.end()) {
-            return out;
+            throw std::runtime_error("JES uncertainty: no correction set / prefix / suffix configured for "
+                                     "year '" + year + "' (source '" + base_source + "'). Refusing to emit "
+                                     "an empty JES variation — add this year to the JEC maps in corrections.h.");
         }
         std::string src = base_source;
         if (yearDecorrelated) {
             auto yt_it = year_token_map.find(year);
-            if (yt_it == year_token_map.end()) return out;
+            if (yt_it == year_token_map.end()) {
+                throw std::runtime_error("JES uncertainty: no year token configured for year '" + year
+                                         + "' (needed for year-decorrelated source '" + base_source
+                                         + "'). Add it to jetEnergyCorrections_yearToken in corrections.h.");
+            }
             src += "_" + yt_it->second;
         }
         const std::string unc_name = pf_it->second + "_" + src + "_" + sf_it->second;
@@ -475,12 +500,10 @@ auto makeJESShiftEvaluator(
         try {
             unc = cs_it->second.at(unc_name);
         } catch (const std::out_of_range&) {
-            static std::unordered_set<std::string> warned;
-            if (warned.insert(year + "/" + unc_name).second) {
-                std::cout << "Warning: JEC uncertainty source '" << unc_name
-                          << "' not found for year " << year << "." << std::endl;
-            }
-            return out;
+            throw std::runtime_error("JES uncertainty: source '" + unc_name
+                                     + "' not found in the pinned jerc file for year '" + year
+                                     + "'. The JEC tag string in corrections.h is stale relative to the "
+                                       "pinned snapshot (version drift). Refusing to emit an empty variation.");
         }
         for (size_t i = 0; i < pt.size(); ++i) {
             float u = unc->evaluate({(double)eta[i], (double)pt[i]});
@@ -490,25 +513,6 @@ auto makeJESShiftEvaluator(
     };
 }
 
-// Type-I-style MET shift: rebuilds (met_pt, met_phi) from (pt_old - pt_new) per AK4 jet,
-// applying the standard >15 GeV / emf<0.9 filter.
-auto jesMetPropagator() {
-    return [](RVec<float> pt_old, RVec<float> pt_new, RVec<float> phi,
-              RVec<float> neEmEF, RVec<float> chEmEF,
-              float met_pt, float met_phi) {
-        double px = met_pt * std::cos(met_phi);
-        double py = met_pt * std::sin(met_phi);
-        for (size_t i = 0; i < pt_old.size(); ++i) {
-            if (pt_new[i] <= 15.0f) continue;
-            if ((neEmEF[i] + chEmEF[i]) > 0.9f) continue;
-            const double dpt = static_cast<double>(pt_old[i] - pt_new[i]);
-            px += dpt * std::cos(phi[i]);
-            py += dpt * std::sin(phi[i]);
-        }
-        return std::make_pair(static_cast<float>(std::sqrt(px*px + py*py)),
-                              static_cast<float>(std::atan2(py, px)));
-    };
-}
 } // anonymous namespace
 
 RNode defineAK4JESVariation(
@@ -522,21 +526,17 @@ RNode defineAK4JESVariation(
     const float sign = (direction == "Up") ? +1.0f : -1.0f;
     const std::string sfx = "jes" + column_label + direction;
     const std::string shiftCol = "_Jet_shift_" + sfx;
-    const std::string metPropCol = "_metProp_" + sfx;
 
     auto eval_factor = makeJESShiftEvaluator(cset_jerc, jec_prefix_map, jec_suffix_map,
                                              year_token_map, base_source, yearDecorrelated, sign);
-    auto met_prop = jesMetPropagator();
 
+    // Writes the per-jet shift factor (_Jet_shift_<sfx>) and the shifted Jet kinematics.
+    // The matching met_pt_<sfx> / met_phi_<sfx> are built in applyType1MET(), which reads
+    // _Jet_shift_<sfx> and rebuilds the Type-I MET from RawPuppiMET for this variation.
     return df
         .Define(shiftCol, eval_factor, {"year", "Jet_pt", "Jet_eta"})
         .Define("Jet_pt_"   + sfx, "Jet_pt   * " + shiftCol)
-        .Define("Jet_mass_" + sfx, "Jet_mass * " + shiftCol)
-        .Define(metPropCol, met_prop,
-                {"Jet_pt", "Jet_pt_" + sfx, "Jet_phi", "Jet_neEmEF", "Jet_chEmEF",
-                 "met_pt", "met_phi"})
-        .Define("met_pt_"  + sfx, [](std::pair<float,float> p){ return p.first;  }, {metPropCol})
-        .Define("met_phi_" + sfx, [](std::pair<float,float> p){ return p.second; }, {metPropCol});
+        .Define("Jet_mass_" + sfx, "Jet_mass * " + shiftCol);
 }
 
 RNode defineFatJetJESVariation(
@@ -568,8 +568,7 @@ struct JESSourceSpec {
 };
 
 // 11 Regrouped V2 sources — confirmed against jet_jerc.json.gz / fatJet_jerc.json.gz
-// for all 9 campaigns on 2026-05-14. JME-POG standard set; combine treats the *_Year
-// entries as uncorrelated across years (handled downstream via the `year` hist axis).
+// for all 9 campaigns on 2026-05-14. JME-POG standard set;
 static const std::vector<JESSourceSpec> kJESRegroupedSources = {
     {"Absolute",            "Regrouped_Absolute",       false},
     {"BBEC1",               "Regrouped_BBEC1",          false},
@@ -623,6 +622,256 @@ std::vector<std::string> jesVariationSuffixes() {
 
 /*
 ############################################
+TYPE-1 PUPPI MET — full rebuild from RawPuppiMET
+############################################
+
+Matches the central JERC application tutorial (cms-analysis/jme/jerc-application-tutorial,
+JecApplication.cpp::correctedMet + JecApplication.py::_recompute_type1_met) and the JERC
+Type-1 MET recipe (Type1MET.pdf, 2026-04-17):
+
+  MET_T1 = RawPuppiMET + Σ_jets  p⃗_raw,musub · (c_L1 − c_full)
+
+summed over the *merged* AK4 list (Jet + CorrT1METJet). For PUPPI the L1FastJet offset
+c_L1 ≡ 1.0 (verified for AK4PFPuppi across all 9 eras in the pinned 2026-06-05 files), so
+the per-jet contribution is  p⃗_raw,musub · (1 − c_full).
+
+Per jet:
+  * p_raw       = (1 − rawFactor) · pt              (CorrT1METJet ships rawPt directly)
+  * p_raw,musub = p_raw · (1 − muonSubtrFactor)     direction = phi + muonSubtrDeltaPhi
+  * c_full      = c_JEC · c_JER · c_JES-shift        (c_JEC = L1L2L3Res compound at p_raw,musub)
+  * selection   : (chEmEF+neEmEF) < 0.9, |eta| < 5.2, and c_full · p_raw,musub > 15 GeV
+  * baseline    : RawPuppiMET (NOT PuppiMET — PuppiMET already has Type-1 applied)
+
+Decisions / scope (documented for the review):
+  - c_L1 = 1 hardcoded (PUPPI). If a future file gives L1 ≠ 1, this must evaluate L1FastJet.
+    (The tutorial evaluates L1FastJet explicitly; identical to c_L1=1 for PUPPI.)
+  - JEC compound evaluated at the muon-subtracted pt (matches the tutorial's per-level chain,
+    which feeds ptRawMinusMuon through L1·L2·L3). Muon-jets are the only ones affected.
+  - Direction = phi + muonSubtrDeltaPhi, per Type1MET.pdf §1.5 (accounts for the jet's
+    direction change when the muon is removed). NOTE: the JERC tutorial code and getT1CHSMET
+    use the plain jet phi here; we deliberately follow the PDF instead.
+  - BOTH collections (Jet and CorrT1METJet) carry the full JEC·JER·JES-shift per scenario —
+    no approximation. CorrT1METJet get their own gen-matched JER (ΔR<0.2 to GenJet, then
+    JERSmear) and their own per-source JES shift, exactly like the main jets.
+      · main-jet JER = the analysis Jet_jerFactor (evaluated on the JEC pt, consistent with
+        the jets used in the event selection);
+      · CorrT1METJet JER = gen-matched JERSmear on their JEC muon-subtracted pt (they have no
+        Jet_genJetIdx, so we ΔR-match to GenJet as the JERC tutorial does).
+    JES shift is evaluated at the JEC·JER-corrected pt for both (nominal-JER × per-source
+    shift), matching this framework's main-jet convention.
+  - MET-φ corrections (Run 2) are applied afterwards, on top of this rebuilt MET.
+*/
+
+namespace {
+
+// Per-(main-)jet building blocks for the Type-1 MET sum. Computed once, reused by the
+// nominal MET and every JES variation (which only swap the per-jet shift factor).
+struct T1JetBlocks {
+    RVec<double> rmpx, rmpy;   // raw muon-subtracted momentum comps (direction = phi + muonSubtrDeltaPhi)
+    RVec<double> corrjec;      // JEC factor (L1L2L3Res compound at the muon-subtracted pt)
+    RVec<double> rawmusubpt;   // |raw muon-subtracted pT|, for the 15 GeV threshold
+    RVec<unsigned char> pass;  // selection: (neEmEF + chEmEF) < 0.9 and |eta| < 5.2
+};
+
+// If column `src` exists, alias `out`->`src`; otherwise Define `out` as an RVec<float> of
+// `fill`, length matching `sizeRef`. Lets the rebuild tolerate NanoAOD versions lacking
+// muonSubtrDeltaPhi / CorrT1METJet_EmEF, and the data path lacking Jet_jerFactor.
+RNode aliasOrFill(RNode df, const std::string& out, const std::string& src,
+                  const std::string& sizeRef, float fill) {
+    auto cols = df.GetColumnNames();
+    if (std::find(cols.begin(), cols.end(), src) != cols.end())
+        return df.Alias(out, src);
+    return df.Define(out, [fill](const RVec<float>& ref) { return RVec<float>(ref.size(), fill); },
+                     {sizeRef});
+}
+
+} // anonymous namespace
+
+RNode applyType1MET(RNode df, bool isData) {
+    // Tolerate optional / MC-only branches.
+    df = aliasOrFill(df, "_t1_jet_musubDphi", "Jet_muonSubtrDeltaPhi",          "Jet_eta",          0.0f);
+    df = aliasOrFill(df, "_t1_jer",           "Jet_jerFactor",                  "Jet_eta",          1.0f);
+    df = aliasOrFill(df, "_t1_ct1_musubDphi", "CorrT1METJet_muonSubtrDeltaPhi", "CorrT1METJet_eta", 0.0f);
+    df = aliasOrFill(df, "_t1_ct1_EmEF",      "CorrT1METJet_EmEF",              "CorrT1METJet_eta", 0.0f);
+    // Single EM-fraction column so the block builder is shared with CorrT1METJet.
+    df = df.Define("_t1_jet_emfrac", "Jet_neEmEF + Jet_chEmEF");
+
+    // --- shared per-jet block builder (used for both Jet and CorrT1METJet) ---------------
+    auto build_blocks = [isData](
+            std::string year,
+            const RVec<float>& rawpt, const RVec<float>& eta, const RVec<float>& phi,
+            const RVec<float>& area,  const RVec<float>& musubF, const RVec<float>& musubDphi,
+            const RVec<float>& emFrac,
+            float rho, unsigned int run) {
+        T1JetBlocks b;
+        const size_t n = rawpt.size();
+        b.rmpx.resize(n); b.rmpy.resize(n); b.corrjec.resize(n);
+        b.rawmusubpt.resize(n); b.pass.resize(n);
+        if (n == 0) return b;
+        const auto& cs = jetEnergyCorrections.at(year);
+        const std::string cname = makeCompoundJECName(jetEnergyCorrections_JEC_prefix.at(year),
+                                                      jetEnergyCorrections_JEC_suffix.at(year), isData);
+        auto comp = cs.compound().at(cname);
+        for (size_t i = 0; i < n; ++i) {
+            const double rawmusubpt = (double)rawpt[i] * (1.0 - (double)musubF[i]);
+            // MET-shift direction = phi + muonSubtrDeltaPhi, per Type1MET.pdf §1.5 (accounts
+            // for the jet's direction change when the muon is removed; falls back to phi when
+            // the branch is absent, via the 0-filled musubDphi column).
+            const double dir = (double)phi[i] + (double)musubDphi[i];
+            b.rmpx[i] = rawmusubpt * std::cos(dir);
+            b.rmpy[i] = rawmusubpt * std::sin(dir);
+            b.rawmusubpt[i] = rawmusubpt;
+            double sf = 1.0;
+            try {
+                // JEC chain evaluated on the muon-subtracted pt (JERC tutorial JecApplication.cpp).
+                sf = evalJECCompound(*comp, (double)area[i], (double)eta[i], rawmusubpt,
+                                     (double)rho, (double)phi[i], (double)run);
+            } catch (const std::exception& e) {
+                std::cout << "Warning: JEC evaluation failed for MET jet " << i << " (musub_pt=" << rawmusubpt
+                          << ", eta=" << eta[i] << "): " << e.what() << ". Setting SF to 1.0." << std::endl;
+                sf = 1.0;
+            }
+            b.corrjec[i] = sf;
+            b.pass[i] = (emFrac[i] < 0.9f && std::abs((double)eta[i]) < 5.2) ? 1 : 0;
+        }
+        return b;
+    };
+    // Handle Jet collection
+    df = df.Define("_t1_jet_blocks", build_blocks,
+                   {"year", "_Jet_rawpt", "Jet_eta", "Jet_phi", "Jet_area",
+                    "Jet_muonSubtrFactor", "_t1_jet_musubDphi", "_t1_jet_emfrac",
+                    "Rho_fixedGridRhoFastjetAll", "run"});
+    // Handle CorrT1METJet collection (already raw pt, no rawFactor)                  
+    df = df.Define("_t1_ct1_blocks", build_blocks,
+                   {"year", "CorrT1METJet_rawPt", "CorrT1METJet_eta", "CorrT1METJet_phi",
+                    "CorrT1METJet_area", "CorrT1METJet_muonSubtrFactor", "_t1_ct1_musubDphi",
+                    "_t1_ct1_EmEF", "Rho_fixedGridRhoFastjetAll", "run"});
+
+    // Nominal per-jet "shift" = 1, sized to each collection.
+    auto ones_like = [](const T1JetBlocks& b) { return RVec<float>(b.corrjec.size(), 1.0f); };
+    df = df.Define("_t1_jet_ones", ones_like, {"_t1_jet_blocks"});
+    df = df.Define("_t1_ct1_ones", ones_like, {"_t1_ct1_blocks"});
+
+    // --- CorrT1METJet JER: gen-matched (ΔR<0.2 to GenJet) JERSmear on the JEC musub pt -----
+    // (main-jet JER is the analysis Jet_jerFactor, already in _t1_jer). Data → ones.
+    if (!isData) {
+        auto build_ct1_jer = [](std::string year, const T1JetBlocks& b,
+                                const RVec<float>& eta, const RVec<float>& phi,
+                                const RVec<float>& gpt, const RVec<float>& geta, const RVec<float>& gphi,
+                                float rho, unsigned long long event) {
+            RVec<float> jer(b.corrjec.size(), 1.0f);
+            if (b.corrjec.empty()) return jer;
+            std::shared_ptr<const correction::Correction> res, sf;
+            std::shared_ptr<const correction::Correction> smear;
+            try {
+                res   = jetEnergyCorrections.at(year).at(jetEnergyResolution_JER_res_name.at(year));
+                sf    = jetEnergyCorrections.at(year).at(jetEnergyResolution_JER_sf_name.at(year));
+                smear = jetEnergyResolution_smear.at("jer_smear").at("JERSmear");
+            } catch (const std::out_of_range&) {
+                throw std::runtime_error("CorrT1METJet JER: res/sf/smear key missing for year '" + year
+                                         + "'. Stale JER tag vs pinned snapshot (see corrections.h).");
+            }
+            for (size_t i = 0; i < b.corrjec.size(); ++i) {
+                const double pt_jec = b.rawmusubpt[i] * b.corrjec[i];   // JEC-corrected musub pt
+                // Nearest GenJet within ΔR<0.2 (CorrT1METJet has no Jet_genJetIdx).
+                float gen_pt = -1.0f; double best = 0.2 * 0.2;
+                for (size_t g = 0; g < gpt.size(); ++g) {
+                    const double dphi = std::atan2(std::sin((double)phi[i] - (double)gphi[g]),
+                                                   std::cos((double)phi[i] - (double)gphi[g]));
+                    const double deta = (double)eta[i] - (double)geta[g];
+                    const double dr2  = deta * deta + dphi * dphi;
+                    if (dr2 < best) { best = dr2; gen_pt = gpt[g]; }
+                }
+                const double r  = evalJERCorrection(*res, (double)eta[i], pt_jec, (double)rho, "nom");
+                const double s  = evalJERCorrection(*sf,  (double)eta[i], pt_jec, (double)rho, "nom");
+                const double sm = smear->evaluate({pt_jec, (double)eta[i], (double)gen_pt,
+                                                   (double)rho, (int)event, r, s});
+                jer[i] = static_cast<float>(sm);
+            }
+            return jer;
+        };
+        df = df.Define("_t1_ct1_jer", build_ct1_jer,
+                       {"year", "_t1_ct1_blocks", "CorrT1METJet_eta", "CorrT1METJet_phi",
+                        "GenJet_pt", "GenJet_eta", "GenJet_phi", "Rho_fixedGridRhoFastjetAll", "event"});
+    } else {
+        df = df.Alias("_t1_ct1_jer", "_t1_ct1_ones");
+    }
+
+    // CorrT1METJet JEC·JER-corrected pt — the pt at which the JES source is evaluated.
+    df = df.Define("_t1_ct1_corrpt",
+                   [](const T1JetBlocks& b, const RVec<float>& jer) {
+                       RVec<float> o(b.corrjec.size());
+                       for (size_t i = 0; i < b.corrjec.size(); ++i)
+                           o[i] = static_cast<float>(b.rawmusubpt[i] * b.corrjec[i]
+                                                     * (i < jer.size() ? (double)jer[i] : 1.0));
+                       return o;
+                   },
+                   {"_t1_ct1_blocks", "_t1_ct1_jer"});
+
+    // Per-source CorrT1METJet JES shift columns (same 22 Regrouped sources as the main jets).
+    if (!isData && g_storeSysts) {
+        for (const auto& src : kJESRegroupedSources) {
+            for (const char* dir : kJESDirections) {
+                const float sign = (std::string(dir) == "Up") ? +1.0f : -1.0f;
+                auto eval = makeJESShiftEvaluator(jetEnergyCorrections,
+                                                  jetEnergyCorrections_JEC_prefix,
+                                                  jetEnergyCorrections_JEC_suffix,
+                                                  jetEnergyCorrections_yearToken,
+                                                  src.base_source, src.yearDecorrelated, sign);
+                df = df.Define("_t1_ct1_shift_jes" + std::string(src.label) + dir, eval,
+                               {"year", "_t1_ct1_corrpt", "CorrT1METJet_eta"});
+            }
+        }
+    }
+
+    // --- assemble a MET for one scenario: sum both collections, corr_full = corrjec*jer*shift ---
+    auto met_from = [](const T1JetBlocks& jb, const RVec<float>& jjer, const RVec<float>& jshift,
+                       const T1JetBlocks& cb, const RVec<float>& cjer, const RVec<float>& cshift,
+                       float rawmet_pt, float rawmet_phi) {
+        double px = (double)rawmet_pt * std::cos((double)rawmet_phi);
+        double py = (double)rawmet_pt * std::sin((double)rawmet_phi);
+        auto add = [&px, &py](const T1JetBlocks& b, const RVec<float>& jer, const RVec<float>& shift) {
+            for (size_t i = 0; i < b.corrjec.size(); ++i) {
+                if (!b.pass[i]) continue;
+                const double jf = (i < jer.size())   ? (double)jer[i]   : 1.0;
+                const double sh = (i < shift.size()) ? (double)shift[i] : 1.0;
+                const double corr_full = b.corrjec[i] * jf * sh;         // c_L1 = 1 (PUPPI)
+                if (corr_full * b.rawmusubpt[i] <= 15.0) continue;       // Type-I threshold on full pT
+                px += b.rmpx[i] * (1.0 - corr_full);
+                py += b.rmpy[i] * (1.0 - corr_full);
+            }
+        };
+        add(jb, jjer, jshift);
+        add(cb, cjer, cshift);
+        return std::make_pair(static_cast<float>(std::hypot(px, py)),
+                              static_cast<float>(std::atan2(py, px)));
+    };
+
+    // Nominal MET (JEC·JER on both collections; JER=1 in data via the _t1_*_ones fallbacks).
+    df = df.Define("_t1_met_nom", met_from,
+                   {"_t1_jet_blocks", "_t1_jer", "_t1_jet_ones",
+                    "_t1_ct1_blocks", "_t1_ct1_jer", "_t1_ct1_ones",
+                    "RawPuppiMET_pt", "RawPuppiMET_phi"});
+    df = df.Define("met_pt",  "(float)_t1_met_nom.first");
+    df = df.Define("met_phi", "(float)_t1_met_nom.second");
+
+    // Per-variation MET: swap in the JES shift for BOTH collections.
+    if (!isData) {
+        for (const auto& sfx : jesVariationSuffixes()) {
+            const std::string metCol = "_t1_met_" + sfx;
+            df = df.Define(metCol, met_from,
+                           {"_t1_jet_blocks", "_t1_jer", "_Jet_shift_" + sfx,
+                            "_t1_ct1_blocks", "_t1_ct1_jer", "_t1_ct1_shift_" + sfx,
+                            "RawPuppiMET_pt", "RawPuppiMET_phi"});
+            df = df.Define("met_pt_"  + sfx, "(float)" + metCol + ".first");
+            df = df.Define("met_phi_" + sfx, "(float)" + metCol + ".second");
+        }
+    }
+    return df;
+}
+
+/*
+############################################
 JET ENERGY RESOLUTION — hybrid smearing (MC only)
 ############################################
 
@@ -660,12 +909,9 @@ RNode applyJetEnergyResolution(const std::unordered_map<std::string, correction:
         auto sn_it = jer_sf_map.find(year);
         if (cs_it == cset_jerc.end() || sm_it == cset_jer_smear.end()
             || rn_it == jer_res_map.end() || sn_it == jer_sf_map.end()) {
-            static std::unordered_set<std::string> warned;
-            if (warned.insert(year).second) {
-                std::cout << "Warning: JER inputs missing for year " << year
-                          << ". Skipping JER smearing." << std::endl;
-            }
-            return factor;
+            throw std::runtime_error("AK4 JER: resolution / SF / smear inputs not configured for year '"
+                                     + year + "'. Refusing to run with jets un-smeared — add this year to the "
+                                       "JER maps in corrections.h.");
         }
 
         std::shared_ptr<const correction::Correction> res, sf, smear;
@@ -674,22 +920,17 @@ RNode applyJetEnergyResolution(const std::unordered_map<std::string, correction:
             sf    = cs_it->second.at(sn_it->second);
             smear = sm_it->second.at("JERSmear");
         } catch (const std::out_of_range&) {
-            static std::unordered_set<std::string> warned;
-            if (warned.insert(year).second) {
-                std::cout << "Warning: JER res/sf/smear key missing for year " << year
-                          << " (res=" << rn_it->second << " sf=" << sn_it->second
-                          << "). Skipping JER smearing." << std::endl;
-            }
-            return factor;
+            throw std::runtime_error("AK4 JER: a res/sf key (res='" + rn_it->second + "', sf='" + sn_it->second
+                                     + "') was not found in the pinned jet_jerc.json.gz for year '" + year
+                                     + "'. The JER tag string in corrections.h is stale relative to the pinned "
+                                       "snapshot (version drift). Refusing to run with jets un-smeared.");
         }
 
-        const bool sf_has_pt = (sf->inputs().size() >= 3);
         for (size_t i = 0; i < pt.size(); ++i) {
             const float gen_pt = (genJet_idx[i] >= 0 && genJet_idx[i] < (int)genJet_pt.size())
                                      ? genJet_pt[genJet_idx[i]] : -1.0f;
-            double r  = res->evaluate({(double)eta[i], (double)pt[i], (double)rho});
-            double s  = sf_has_pt ? sf->evaluate({(double)eta[i], (double)pt[i], vary})
-                                  : sf->evaluate({(double)eta[i], vary});
+            double r  = evalJERCorrection(*res, (double)eta[i], (double)pt[i], (double)rho, vary);
+            double s  = evalJERCorrection(*sf,  (double)eta[i], (double)pt[i], (double)rho, vary);
             double sm = smear->evaluate({(double)pt[i], (double)eta[i], (double)gen_pt,
                                          (double)rho, (int)event, r, s});
             factor[i] = static_cast<float>(sm);
@@ -697,33 +938,13 @@ RNode applyJetEnergyResolution(const std::unordered_map<std::string, correction:
         return factor;
     };
 
-    auto met_propagate_jer = [](RVec<float> pt_pre, RVec<float> factor, RVec<float> phi,
-                                RVec<float> neEmEF, RVec<float> chEmEF,
-                                float met_pt, float met_phi) {
-        double px = met_pt * std::cos(met_phi);
-        double py = met_pt * std::sin(met_phi);
-        for (size_t i = 0; i < pt_pre.size(); ++i) {
-            const float pt_new = pt_pre[i] * factor[i];
-            if (pt_new <= 15.0f) continue;
-            if ((neEmEF[i] + chEmEF[i]) > 0.9f) continue;
-            const double dpt = static_cast<double>(pt_pre[i] - pt_new);
-            px += dpt * std::cos(phi[i]);
-            py += dpt * std::sin(phi[i]);
-        }
-        return std::make_pair(static_cast<float>(std::sqrt(px*px + py*py)),
-                              static_cast<float>(std::atan2(py, px)));
-    };
-
+    // NOTE: MET is no longer propagated here. Jet_jerFactor is consumed by applyType1MET(),
+    // which folds JEC*JER into the per-jet correction when rebuilding the Type-I MET from
+    // RawPuppiMET. This function only smears the jets.
     return df
         .Define("Jet_jerFactor", compute_smear,
                 {"year", "Jet_pt", "Jet_eta", "Jet_genJetIdx", "GenJet_pt",
                  "Rho_fixedGridRhoFastjetAll", "event"})
-        .Define("_Jet_pt_preJER", "Jet_pt")
-        .Define("_jer_metProp", met_propagate_jer,
-                {"_Jet_pt_preJER", "Jet_jerFactor", "Jet_phi",
-                 "Jet_neEmEF", "Jet_chEmEF", "met_pt", "met_phi"})
-        .Redefine("met_pt",   "_jer_metProp.first")
-        .Redefine("met_phi",  "_jer_metProp.second")
         .Redefine("Jet_pt",   "Jet_pt   * Jet_jerFactor")
         .Redefine("Jet_mass", "Jet_mass * Jet_jerFactor");
 }
@@ -760,12 +981,9 @@ RNode applyFatJetEnergyResolution(const std::unordered_map<std::string, correcti
         auto sn_it = jer_sf_map.find(year);
         if (cs_it == cset_jerc.end() || sm_it == cset_jer_smear.end()
             || rn_it == jer_res_map.end() || sn_it == jer_sf_map.end()) {
-            static std::unordered_set<std::string> warned;
-            if (warned.insert(year).second) {
-                std::cout << "Warning: AK8 JER inputs missing for year " << year
-                          << ". Skipping AK8 JER smearing." << std::endl;
-            }
-            return factor;
+            throw std::runtime_error("AK8 JER: resolution / SF / smear inputs not configured for year '"
+                                     + year + "'. Refusing to run with fat jets un-smeared — add this year to "
+                                       "the JER maps in corrections.h.");
         }
 
         std::shared_ptr<const correction::Correction> res, sf, smear;
@@ -774,22 +992,17 @@ RNode applyFatJetEnergyResolution(const std::unordered_map<std::string, correcti
             sf    = cs_it->second.at(sn_it->second);
             smear = sm_it->second.at("JERSmear");
         } catch (const std::out_of_range&) {
-            static std::unordered_set<std::string> warned;
-            if (warned.insert(year).second) {
-                std::cout << "Warning: AK8 JER res/sf/smear key missing for year " << year
-                          << " (res=" << rn_it->second << " sf=" << sn_it->second
-                          << "). Skipping AK8 JER smearing." << std::endl;
-            }
-            return factor;
+            throw std::runtime_error("AK8 JER: a res/sf key (res='" + rn_it->second + "', sf='" + sn_it->second
+                                     + "') was not found in the pinned fatJet_jerc.json.gz for year '" + year
+                                     + "'. The JER tag string in corrections.h is stale relative to the pinned "
+                                       "snapshot (version drift). Refusing to run with fat jets un-smeared.");
         }
 
-        const bool sf_has_pt = (sf->inputs().size() >= 3);
         for (size_t i = 0; i < pt.size(); ++i) {
             const float gen_pt = (genJet_idx[i] >= 0 && genJet_idx[i] < (int)genJet_pt.size())
                                      ? genJet_pt[genJet_idx[i]] : -1.0f;
-            double r  = res->evaluate({(double)eta[i], (double)pt[i], (double)rho});
-            double s  = sf_has_pt ? sf->evaluate({(double)eta[i], (double)pt[i], vary})
-                                  : sf->evaluate({(double)eta[i], vary});
+            double r  = evalJERCorrection(*res, (double)eta[i], (double)pt[i], (double)rho, vary);
+            double s  = evalJERCorrection(*sf,  (double)eta[i], (double)pt[i], (double)rho, vary);
             double sm = smear->evaluate({(double)pt[i], (double)eta[i], (double)gen_pt,
                                          (double)rho, (int)event, r, s});
             factor[i] = static_cast<float>(sm);
@@ -949,9 +1162,11 @@ GENERAL CORRECTIONS
 */
 
 RNode applyDataCorrections(RNode df_) {
-    auto df = applyMETPhiCorrections(df_, true);
-    // Re-apply the latest JEC stack (raw recovery + L1*L2*L3*Residual compound).
-    // AK4 propagates to MET; AK8 does not (PuppiMET only includes AK4 Type-I).
+    // Snapshot the raw AK4 pt before JEC mutates Jet_pt — applyType1MET rebuilds the MET
+    // from these raw jets (Jet_rawFactor is reset by JEC, so raw pt can't be recovered later).
+    auto df = df_.Define("_Jet_rawpt", "(1.0f - Jet_rawFactor) * Jet_pt");
+    // Re-apply the latest JEC stack (raw recovery + L1*L2*L3*Residual compound). No MET
+    // propagation here — Type-I MET is rebuilt from RawPuppiMET in applyType1MET below.
     df = applyJetEnergyCorrections(jetEnergyCorrections,
                                    jetEnergyCorrections_JEC_prefix,
                                    jetEnergyCorrections_JEC_suffix,
@@ -960,14 +1175,20 @@ RNode applyDataCorrections(RNode df_) {
                                       fatJetEnergyCorrections_JEC_prefix,
                                       fatJetEnergyCorrections_JEC_suffix,
                                       df, /*isData=*/true);
+    // Rebuild Type-I MET (nominal only for data), then apply the Run 2 MET-φ correction on top.
+    df = applyType1MET(df, /*isData=*/true);
+    df = applyMETPhiCorrections(df, true);
     df = HEMCorrection(df, true);
     df = applyElectronScaleAndSmearing(df, true);
     return df;
 }
 
 RNode applyMCCorrections(RNode df_) {
-    auto df = applyMETPhiCorrections(df_, false);
-    // Nominal JEC for AK4 and AK8.
+    // Snapshot the raw AK4 pt before JEC mutates Jet_pt — applyType1MET rebuilds the MET from
+    // these raw jets (Jet_rawFactor is reset by JEC + JER doesn't update it, so raw pt can't be
+    // recovered from the mutated columns afterwards).
+    auto df = df_.Define("_Jet_rawpt", "(1.0f - Jet_rawFactor) * Jet_pt");
+    // Nominal JEC for AK4 and AK8 (no MET propagation here).
     df = applyJetEnergyCorrections(jetEnergyCorrections,
                                    jetEnergyCorrections_JEC_prefix,
                                    jetEnergyCorrections_JEC_suffix,
@@ -976,7 +1197,7 @@ RNode applyMCCorrections(RNode df_) {
                                       fatJetEnergyCorrections_JEC_prefix,
                                       fatJetEnergyCorrections_JEC_suffix,
                                       df, /*isData=*/false);
-    // JER smearing on top of JEC-corrected jets.
+    // JER smearing on top of JEC-corrected jets (defines Jet_jerFactor, consumed by applyType1MET).
     df = applyJetEnergyResolution(jetEnergyCorrections,
                                   jetEnergyResolution_smear,
                                   jetEnergyResolution_JER_res_name,
@@ -988,13 +1209,16 @@ RNode applyMCCorrections(RNode df_) {
                                      fatJetEnergyResolution_JER_sf_name,
                                      df, /*variation=*/"nominal");
     // JES uncertainties — 11 Regrouped V2 sources × {Up, Dn} as suffixed branches.
-    // Must run after the nominal JEC+JER so the shift sits on top of the corrected baseline.
+    // Must run after the nominal JEC+JER so the shift sits on top of the corrected baseline
+    // (defines _Jet_shift_<sfx>, consumed by applyType1MET for the per-variation MET).
     if (g_storeSysts) df = applyJESVariations(df);
-    // JMS / JMR on FatJet_msoftdrop. Currently no-op: centrals are placeholders
-    // (shift = 0 GeV, factor = 1.0). Replace jetMassScale_central / jetMassResolution_central
-    // in corrections.h with the values derived from the per-analysis calibration fit.
-    df = applyJetMassScale(jetMassScale_central, df);
-    df = applyJetMassResolution(jetMassResolution_central, jetMassResolution_sigmaRel_central, df);
+    // Rebuild Type-I MET from RawPuppiMET over Jet + CorrT1METJet, for the nominal and every
+    // JES variation, then apply the Run 2 MET-φ correction on top of the nominal MET.
+    df = applyType1MET(df, /*isData=*/false);
+    df = applyMETPhiCorrections(df, false);
+    // GloParT JMS/JMR would be wired here via applyJetMassScale / applyJetMassResolution
+    // once the calibration is derived. FatJet_msoftdrop is intentionally not calibrated
+    // (loose object cut only; GloParT is used in the rest of the analysis) — see CORRECTIONS.md § 5-6.
     df = HEMCorrection(df, false);
     df = applyElectronScaleAndSmearing(df, false);
     return df;

--- a/preselection/src/corrections.cpp
+++ b/preselection/src/corrections.cpp
@@ -1,8 +1,301 @@
 #include "corrections.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <iostream>
+#include <map>
+#include <stdexcept>
+#include <unordered_set>
 #include <utility>
+
+#include "TRandom3.h"
+
+/*
+############################################
+CORRECTION-SET REGISTRY — single definition point for all correctionlib payloads
+############################################
+
+Everything in this section used to be namespace-scope map definitions in
+corrections.h. Namespace-scope `const` has internal linkage, so every
+translation unit including the header built its own private copy — each
+payload was gzip-decompressed and parsed once per TU, at static-init time
+before main() (where a missing cvmfs file meant std::terminate with no usable
+message). The maps are now function-local statics: defined once, loaded
+lazily on first use after main() starts (thread-safe per C++11 magic statics).
+
+The 11 formerly hand-written JERC maps (paths, JEC prefixes/suffixes, year
+tokens, JER res/sf names for AK4 and AK8) are derived from the single era
+table below — adding or re-pinning an era means editing ONE table row.
+*/
+
+namespace {
+
+using CSetMap = std::unordered_map<std::string, correction::CorrectionSet>;
+using StrMap  = std::unordered_map<std::string, std::string>;
+
+/*
+JERC ERA TABLE
+--------------
+Run 2 + the 2022/2023 Run 3 eras are pinned to the 2026-06-05 JME snapshot
+(jet_jerc / fatJet_jerc); the 2024Prompt and 2025 eras are pinned to the newer
+2026-07-16 snapshot (JEC V5/V3, JER JRV2). JER-Smearing is pinned to
+2025-11-03 — NOT the mutable `latest/` symlink. The tag strings below are the
+compound/correction key roots that exist inside those pinned files. The
+"2024Prompt" era uses the Summer24Prompt24 tag (JEC V5 / JER JRV2), and the
+"2025" era (2025 data + Summer24 MC) uses the JME-recommended Summer24Prompt25
+tag (JEC V3 / JER JRV2). The 2026-07-14 update moved the L2L3Residual
+corrections to signed-η (from |η|) and refreshed the JER SFs (evalJECCompound
+already passes signed eta and resolves inputs by name, so no code change was
+needed); 2026-07-16 fixed the V4/V2 DATA L2L3Residual payloads that 2026-07-14
+had failed to actually update (→ tags V5/V3).
+
+correctionlib has no "give me the newest version" API: the code asks for a tag
+by name, so the file snapshot and the requested tag string must be bumped
+together, deliberately, in one table row. Loading from `latest/` while pinning
+the tag string is what previously let the two drift apart (V3 code vs V4 file
+-> silent no-op; now a hard error, see applyJetEnergyCorrections below). 
+
+To adopt a newer JME release: pick the new dated dir, find the new recommended
+tag, and update the snapshot + tags in the row.
+
+Derived name conventions (see the accessors below):
+  JEC compound     : <jecTag>_{MC,DATA}_L1L2L3Res_<algo>
+  JES uncertainty  : <jecTag>_MC_<source>[_<yearToken>]_<algo>
+  JER res / sf     : <jerTag>_MC_{PtResolution,ScaleFactor}_<algo>
+with <algo> = AK4PFPuppi (jet_jerc) or AK8PFPuppi (fatJet_jerc). The year
+token appears in year-decorrelated Regrouped source names (e.g.
+"Summer20UL18NanoV15_V1_MC_Regrouped_Absolute_2018_AK4PFPuppi").
+*/
+struct EraJERC {
+    std::string jmeDir;     // era directory under /cvmfs/cms-griddata.cern.ch/cat/metadata/JME
+    std::string snapshot;   // pinned dated snapshot subdir — NOT the mutable `latest/`
+    std::string jecTag;     // JEC release, without the trailing _MC/_DATA
+    std::string jerTag;     // JER release, without _MC_{PtResolution,ScaleFactor}_<algo>
+    std::string yearToken;  // token in year-decorrelated Regrouped JES source names
+};
+
+const std::map<std::string, EraJERC>& eraJERCTable() {
+    static const std::map<std::string, EraJERC> table = {
+        //  era                      JME era directory                                        snapshot      JEC tag                       JER tag                            year token
+        {"2016preVFP",           {"Run2-2016preVFP-UL-NanoAODv15",                        "2026-06-05", "Summer20UL16APVNanoV15_V1",  "Summer20UL16APV_JRV5",            "2016APV"}},
+        {"2016postVFP",          {"Run2-2016postVFP-UL-NanoAODv15",                       "2026-06-05", "Summer20UL16NanoV15_V1",     "Summer20UL16_JRV5",               "2016"}},
+        {"2017",                 {"Run2-2017-UL-NanoAODv15",                              "2026-06-05", "Summer20UL17NanoV15_V1",     "Summer19UL17_JRV4",               "2017"}},
+        {"2018",                 {"Run2-2018-UL-NanoAODv15",                              "2026-06-05", "Summer20UL18NanoV15_V1",     "Summer19UL18_JRV3",               "2018"}},
+        {"2022Re-recoBCD",       {"Run3-22CDSep23-Summer22-NanoAODv12",                   "2026-06-05", "Summer22_22Sep2023_V4",      "Summer22_22Sep2023_JRV2",         "2022"}},
+        {"2022Re-recoE+PromptFG",{"Run3-22EFGSep23-Summer22EE-NanoAODv12",                "2026-06-05", "Summer22EE_22Sep2023_V4",    "Summer22EE_22Sep2023_JRV2",       "2022EE"}},
+        {"2023PromptC",          {"Run3-23CSep23-Summer23-NanoAODv12",                    "2026-06-05", "Summer23Prompt23_V4",        "Summer23Prompt23_RunCv1234_JRV2", "2023"}},
+        {"2023PromptD",          {"Run3-23DSep23-Summer23BPix-NanoAODv12",                "2026-06-05", "Summer23BPixPrompt23_V4",    "Summer23BPixPrompt23_RunD_JRV2",  "2023BPix"}},
+        // 2024 + 2025: pinned to 2026-07-16, which fixes a 2026-07-14 bug where the V4/V2 DATA
+        // L2L3Residual payloads had not actually been updated (JEC tags bumped to V5/V3 with the fix).
+        {"2024Prompt",           {"Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15", "2026-07-16", "Summer24Prompt24_V5",        "Summer24Prompt24_JRV2",           "2024"}},
+        // 2025 data + Summer24 MC — JME-recommended Summer24Prompt25 (JEC + JER + JES self-contained).
+        {"2025",                 {"Run3-25Prompt-Summer24-NanoAODv15",                    "2026-07-16", "Summer24Prompt25_V3",        "Summer24Prompt25_JRV2",           "2025"}},
+    };
+    return table;
+}
+
+const std::string kJMEBase = "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/";
+
+CSetMap loadEraJERCSets(const std::string& filename) {
+    CSetMap out;
+    for (const auto& [year, era] : eraJERCTable())
+        out.emplace(year, *CorrectionSet::from_file(
+            kJMEBase + era.jmeDir + "/" + era.snapshot + "/" + filename));
+    return out;
+}
+
+template <typename MakeValue>
+StrMap perEra(MakeValue&& make) {
+    StrMap out;
+    for (const auto& [year, era] : eraJERCTable()) out.emplace(year, make(era));
+    return out;
+}
+
+// --- JERC payloads + derived name maps (all keyed by the era table above) ------------
+
+// AK4 and AK8 JEC/JER payloads — jet_jerc / fatJet_jerc under the same pinned era dirs.
+const CSetMap& jetEnergyCorrections()    { static const CSetMap m = loadEraJERCSets("jet_jerc.json.gz");    return m; }
+const CSetMap& fatJetEnergyCorrections() { static const CSetMap m = loadEraJERCSets("fatJet_jerc.json.gz"); return m; }
+
+// JER hybrid-smearing formula (era-independent), pinned to 2025-11-03.
+const CSetMap& jetEnergyResolution_smear() {
+    static const CSetMap m = [] {
+        CSetMap out;
+        out.emplace("jer_smear",
+                    *CorrectionSet::from_file(kJMEBase + "JER-Smearing/2025-11-03/jer_smear.json.gz"));
+        return out;
+    }();
+    return m;
+}
+
+// `<jecTag>_MC` — compound/uncertainty name prefix. Identical for AK4 and AK8 (both live
+// under the same JEC release), so there is a single prefix map. makeCompoundJECName()
+// swaps the trailing _MC for _DATA when running on data.
+const StrMap& jetEnergyCorrections_JEC_prefix() {
+    static const StrMap m = perEra([](const EraJERC& e) { return e.jecTag + "_MC"; });
+    return m;
+}
+
+// Algo suffixes. The value is a property of the jet collection, not the era, but the
+// JEC/JES helpers look their inputs up per year, so these stay year-keyed maps.
+const StrMap& jetEnergyCorrections_JEC_suffix() {
+    static const StrMap m = perEra([](const EraJERC&) { return std::string("AK4PFPuppi"); });
+    return m;
+}
+const StrMap& fatJetEnergyCorrections_JEC_suffix() {
+    static const StrMap m = perEra([](const EraJERC&) { return std::string("AK8PFPuppi"); });
+    return m;
+}
+
+// Year token embedded in the year-decorrelated Regrouped JES source names.
+const StrMap& jetEnergyCorrections_yearToken() {
+    static const StrMap m = perEra([](const EraJERC& e) { return e.yearToken; });
+    return m;
+}
+
+// JER PtResolution / ScaleFactor correction names: `<jerTag>_MC_{PtResolution,ScaleFactor}_<algo>`.
+StrMap makeJERNames(const std::string& kind, const std::string& algo) {
+    return perEra([&](const EraJERC& e) { return e.jerTag + "_MC_" + kind + "_" + algo; });
+}
+const StrMap& jetEnergyResolution_JER_res_name()    { static const StrMap m = makeJERNames("PtResolution", "AK4PFPuppi"); return m; }
+const StrMap& jetEnergyResolution_JER_sf_name()     { static const StrMap m = makeJERNames("ScaleFactor",  "AK4PFPuppi"); return m; }
+const StrMap& fatJetEnergyResolution_JER_res_name() { static const StrMap m = makeJERNames("PtResolution", "AK8PFPuppi"); return m; }
+const StrMap& fatJetEnergyResolution_JER_sf_name()  { static const StrMap m = makeJERNames("ScaleFactor",  "AK8PFPuppi"); return m; }
+
+// JER SF uncertainty (split-tag format, JME 2026-06-04 "newJERFormats" update). The pinned
+// ScaleFactor corrections carry NO `systematic` input; the ±1σ SF is ScaleFactor ± SFUncertainty
+// (verified against the last old-format payload: reproduces the old up/down to <=1e-4).
+const StrMap& jetEnergyResolution_JER_unc_name()    { static const StrMap m = makeJERNames("SFUncertainty", "AK4PFPuppi"); return m; }
+const StrMap& fatJetEnergyResolution_JER_unc_name() { static const StrMap m = makeJERNames("SFUncertainty", "AK8PFPuppi"); return m; }
+
+// --- B-tagging -----------------------------------------------------------------------
+
+// Note: Re-using the 2024 payload for 2022-2023 (same Run3-24... file).
+// 2025 recommendation: https://btv-wiki.docs.cern.ch/ScaleFactors/Run3Prompt25/
+const CSetMap& btaggingCorrections() {
+    static const CSetMap m = [] {
+        const std::string base = "/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/";
+        const std::vector<std::pair<std::string, std::string>> eras = {
+            {"2016preVFP",            "Run2-2016preVFP-UL-NanoAODv15"},
+            {"2016postVFP",           "Run2-2016postVFP-UL-NanoAODv15"},
+            {"2017",                  "Run2-2017-UL-NanoAODv15"},
+            {"2018",                  "Run2-2018-UL-NanoAODv15"},
+            {"2022Re-recoBCD",        "Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15"},
+            {"2022Re-recoE+PromptFG", "Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15"},
+            {"2023PromptC",           "Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15"},
+            {"2023PromptD",           "Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15"},
+            {"2024Prompt",            "Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15"},
+            {"2025",                  "Run3-25Prompt-Summer24-NanoAODv15"},
+        };
+        CSetMap out;
+        for (const auto& [year, dir] : eras)
+            out.emplace(year, *CorrectionSet::from_file(base + dir + "/latest/btagging.json.gz"));
+        return out;
+    }();
+    return m;
+}
+
+// Numeric WP thresholds, one evaluate() per (era, WP) on first use.
+std::unordered_map<std::string, float> makeBtagWPMap(const std::string& wp) {
+    std::unordered_map<std::string, float> out;
+    for (const auto& [year, cs] : btaggingCorrections())
+        out.emplace(year, cs.at("UParTAK4_wp_values")->evaluate({wp}));
+    return out;
+}
+const std::unordered_map<std::string, float>& btaggingWPMap_Loose()  { static const auto m = makeBtagWPMap("L"); return m; }
+const std::unordered_map<std::string, float>& btaggingWPMap_Medium() { static const auto m = makeBtagWPMap("M"); return m; }
+const std::unordered_map<std::string, float>& btaggingWPMap_Tight()  { static const auto m = makeBtagWPMap("T"); return m; }
+
+// --- MET φ corrections ------------------------------------------------------------------
+
+// FIXME: met corrections missing for v15
+const CSetMap& metCorrections() {
+    static const CSetMap m = {
+        {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016preVFP-UL-NanoAODv9/latest/met.json.gz")},
+        {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016postVFP-UL-NanoAODv9/latest/met.json.gz")},
+        {"2017", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2017-UL-NanoAODv9/latest/met.json.gz")},
+        {"2018", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2018-UL-NanoAODv9/latest/met.json.gz")},
+        // {"2022Re-recoBCD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/latest/met_xyCorrections_2022_2022.json.gz")},
+        // {"2022Re-recoE+PromptFG", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22EFGSep23-Summer22EE-NanoAODv12/latest/met_xyCorrections_2022_2022EE.json.gz")},
+        // {"2023PromptC", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23CSep23-Summer23-NanoAODv12/latest/met_xyCorrections_2023_2023.json.gz")},
+        // {"2023PromptD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23DSep23-Summer23BPix-NanoAODv12/latest/met_xyCorrections_2023_2023BPix.json.gz")}
+    };
+    return m;
+}
+
+// --- Jet veto maps ------------------------------------------------------------------
+// Run 2 recommendations: https://cms-jerc.web.cern.ch/Recommendations/#run-2_1
+const CSetMap& jetVetoMaps() {
+    static const CSetMap m = {
+        {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016preVFP-UL-NanoAODv9/latest/jetvetomaps.json.gz")},
+        {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016postVFP-UL-NanoAODv9/latest/jetvetomaps.json.gz")},
+        {"2017", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2017-UL-NanoAODv9/latest/jetvetomaps.json.gz")},
+        {"2018", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2018-UL-NanoAODv9/latest/jetvetomaps.json.gz")},
+        {"2022Re-recoBCD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/latest/jetvetomaps.json.gz")},
+        {"2022Re-recoE+PromptFG", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22EFGSep23-Summer22EE-NanoAODv12/latest/jetvetomaps.json.gz")},
+        {"2023PromptC", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23CSep23-Summer23-NanoAODv12/latest/jetvetomaps.json.gz")},
+        {"2023PromptD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23DSep23-Summer23BPix-NanoAODv12/latest/jetvetomaps.json.gz")},
+        {"2024Prompt", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/latest/jetvetomaps.json.gz")}
+    };
+    return m;
+}
+
+const StrMap jetVetoMap_names = {
+    {"2016preVFP", "Summer19UL16_V1"},
+    {"2016postVFP", "Summer19UL16_V1"},
+    {"2017", "Summer19UL17_V1"},
+    {"2018", "Summer19UL18_V1"},
+    {"2022Re-recoBCD", "Summer22_23Sep2023_RunCD_V1"},
+    {"2022Re-recoE+PromptFG", "Summer22EE_23Sep2023_RunEFG_V1"},
+    {"2023PromptC", "Summer23Prompt23_RunC_V1"},
+    {"2023PromptD", "Summer23BPixPrompt23_RunD_V1"},
+    {"2024Prompt", "Summer24Prompt24_RunBCDEFGHI_V1"}
+};
+
+// --- Electron scale & smearing ---------------------------------------------------------
+const CSetMap& electronSSCorrections() {
+    static const CSetMap m = {
+        {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run2-2016preVFP-UL-NanoAODv15/latest/electronSS_EtDependent.json.gz")},
+        {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run2-2016postVFP-UL-NanoAODv15/latest/electronSS_EtDependent.json.gz")},
+        {"2017", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run2-2017-UL-NanoAODv15/latest/electronSS_EtDependent.json.gz")},
+        {"2018", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run2-2018-UL-NanoAODv15/latest/electronSS_EtDependent.json.gz")},
+        {"2022Re-recoBCD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run3-22CDSep23-Summer22-NanoAODv12/latest/electronSS_EtDependent.json.gz")},
+        {"2022Re-recoE+PromptFG", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run3-22EFGSep23-Summer22EE-NanoAODv12/latest/electronSS_EtDependent.json.gz")},
+        {"2023PromptC", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run3-23CSep23-Summer23-NanoAODv12/latest/electronSS_EtDependent.json.gz")},
+        {"2023PromptD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run3-23DSep23-Summer23BPix-NanoAODv12/latest/electronSS_EtDependent.json.gz")},
+        {"2024Prompt", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/latest/electronSS_EtDependent.json.gz")}
+    };
+    return m;
+}
+
+// --- JMS/JMR placeholder maps (unwired; template for the future GloParT calibration) ----
+// See the JMS/JMR section in corrections.h and CORRECTIONS.md § 5-6. Identity-valued:
+// JMS shift 0.0 GeV, JMR factor 1.0. σ_rel feeds the unmatched stochastic branch of
+// applyJetMassResolution and is unreachable while the factor is 1.0 — replace both
+// together with the per-era values from the calibration fit.
+[[maybe_unused]] const std::unordered_map<std::string, float> jetMassScale_central = {
+    {"2016preVFP", 0.0f}, {"2016postVFP", 0.0f}, {"2017", 0.0f}, {"2018", 0.0f},
+    {"2022Re-recoBCD", 0.0f}, {"2022Re-recoE+PromptFG", 0.0f},
+    {"2023PromptC", 0.0f}, {"2023PromptD", 0.0f},
+    {"2024Prompt", 0.0f}
+};
+
+[[maybe_unused]] const std::unordered_map<std::string, float> jetMassResolution_central = {
+    {"2016preVFP", 1.0f}, {"2016postVFP", 1.0f}, {"2017", 1.0f}, {"2018", 1.0f},
+    {"2022Re-recoBCD", 1.0f}, {"2022Re-recoE+PromptFG", 1.0f},
+    {"2023PromptC", 1.0f}, {"2023PromptD", 1.0f},
+    {"2024Prompt", 1.0f}
+};
+
+[[maybe_unused]] const std::unordered_map<std::string, float> jetMassResolution_sigmaRel_central = {
+    {"2016preVFP", 1.0f}, {"2016postVFP", 1.0f}, {"2017", 1.0f}, {"2018", 1.0f},
+    {"2022Re-recoBCD", 1.0f}, {"2022Re-recoE+PromptFG", 1.0f},
+    {"2023PromptC", 1.0f}, {"2023PromptD", 1.0f},
+    {"2024Prompt", 1.0f}
+};
+
+} // anonymous namespace
 
 /*
 ############################################
@@ -11,218 +304,25 @@ B-TAGGING WORKING POINTS
 */
 
 RVec<bool> isbTagLoose(std::string year, RVec<float> btag_score) {
-    return btag_score > btaggingWPMap_Loose.at(year);
+    return btag_score > btaggingWPMap_Loose().at(year);
 }
 
 RVec<bool> isbTagMedium(std::string year, RVec<float> btag_score) {
-    return btag_score > btaggingWPMap_Medium.at(year);
+    return btag_score > btaggingWPMap_Medium().at(year);
 }
 
 RVec<bool> isbTagTight(std::string year, RVec<float> btag_score) {
-    return btag_score > btaggingWPMap_Tight.at(year);
+    return btag_score > btaggingWPMap_Tight().at(year);
 }
 
 /*
 ############################################
-JET MASS SCALE (JMS) AND RESOLUTION (JMR) — generic, per-mass-column
+JERC EVALUATION HELPERS — shared by the JEC / JER / Type-1 MET code below
 ############################################
 
-Column-agnostic helpers: pass the target mass branch (and, for JMR, the gen
-reference mass + gen-index columns) as arguments so the same code serves
-`FatJet_msoftdrop`, the GloParT regressed mass, or any other analysis mass
-variable.
-
-  JMS  : m' = max(0, m + Δshift[year])                   // additive shift in GeV
-  JMR  : matched   →  m' = max(0, m_gen + f * (m - m_gen))
-         unmatched →  m' = max(0, m * (1 + √max(f²-1,0) * σrel[year] * N(0,1)))
-
-Choice of gen reference `m_gen` matters for GloParT: use whatever the network
-was regressed to (parton W/Z/H mass or particle-level jet mass). For msd, the
-POG-standard proxy is `GenJetAK8_mass[FatJet_genJetAK8Idx]`.
-
-Currently unwired — this analysis calibrates JMS/JMR on the GloParT mass, not
-on msd (§ 5-6 of CORRECTIONS.md), and the GloParT calibration hasn't been
-derived yet. When it lands, wire the calls into `applyMCCorrections` with the
-GloParT column names + per-era shift/factor/σ_rel maps from the calibration
-fit. Up/down systematic variants add a `variation` arg carrying the ±1σ
-shift/scale.
-*/
-
-RNode applyJetMassScale(const std::unordered_map<std::string, float>& shift_map,
-                     const std::string& mass_col,
-                     RNode df) {
-    auto eval = [shift_map, mass_col](std::string year, RVec<float> m) {
-        auto it = shift_map.find(year);
-        if (it == shift_map.end()) {
-            static std::unordered_set<std::string> warned;
-            if (warned.insert(mass_col + "/" + year).second) {
-                std::cout << "Warning: mass-scale shift not defined for year " << year
-                          << " on column " << mass_col << ". Skipping." << std::endl;
-            }
-            return m;
-        }
-        const float shift = it->second;
-        if (shift == 0.0f || m.empty()) return m;
-        for (auto& x : m) x = std::max(0.0f, x + shift);
-        return m;
-    };
-    return df.Redefine(mass_col, eval, {"year", mass_col});
-}
-
-RNode applyJetMassResolution(const std::unordered_map<std::string, float>& factor_map,
-                          const std::unordered_map<std::string, float>& sigma_rel_map,
-                          const std::string& mass_col,
-                          const std::string& gen_mass_col,
-                          const std::string& gen_idx_col,
-                          RNode df) {
-    auto eval = [factor_map, sigma_rel_map, mass_col](std::string year,
-                             RVec<float> m,
-                             RVec<short> gen_idx, RVec<float> gen_mass,
-                             unsigned int lumi, unsigned long long event) {
-        auto it = factor_map.find(year);
-        if (it == factor_map.end()) {
-            static std::unordered_set<std::string> warned;
-            if (warned.insert(mass_col + "/" + year).second) {
-                std::cout << "Warning: mass-resolution factor not defined for year " << year
-                          << " on column " << mass_col << ". Skipping." << std::endl;
-            }
-            return m;
-        }
-        const float f = it->second;
-        if (f == 1.0f || m.empty()) return m;
-
-        const float widen = std::sqrt(std::max(f * f - 1.0f, 0.0f));
-        auto sr_it = sigma_rel_map.find(year);
-        const float sigma_rel = (sr_it != sigma_rel_map.end()) ? sr_it->second : 1.0f;
-        TRandom3 rng((static_cast<unsigned long long>(lumi) << 10) ^ event);
-        for (size_t i = 0; i < m.size(); ++i) {
-            const bool matched = (gen_idx[i] >= 0
-                                  && gen_idx[i] < static_cast<int>(gen_mass.size()));
-            if (matched) {
-                const float m_gen = gen_mass[gen_idx[i]];
-                m[i] = std::max(0.0f, m_gen + f * (m[i] - m_gen));
-            } else {
-                const float kick = static_cast<float>(rng.Gaus(0.0, 1.0));
-                m[i] = std::max(0.0f, m[i] * (1.0f + widen * sigma_rel * kick));
-            }
-        }
-        return m;
-    };
-    return df.Redefine(mass_col, eval,
-                       {"year", mass_col, gen_idx_col, gen_mass_col,
-                        "luminosityBlock", "event"});
-}
-
-/*
-############################################
-HEM Corrections
-############################################
-*/
-
-RNode HEMCorrection(RNode df, bool isData) {
-    auto HEMCorrections = [isData](unsigned int run, unsigned long long event, std::string sample_year, RVec<float> pt, RVec<float> eta, RVec<float> phi, RVec<float> jet_id) {
-        RVec<bool> jet_mask;   
-        if (sample_year == "2018" && ((isData && run >= 319077) || (!isData && event % 100 < 64))) {
-            jet_mask = (jet_id >= 2 && pt > 15.0); // NanoAOD jetID convention https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookNanoAOD#Jets
-                                                    // should still work for current skimmer, which sets jetId==3 : "pass tight ID, fail tightLepVeto", jetId==7 : "pass tight and tightLepVeto ID"
-            auto eta_ = eta[jet_mask];
-            auto phi_ = phi[jet_mask];
-            for (size_t i = 0; i < eta_.size(); i++) {
-                if (eta_[i] > -3.2 && eta_[i] < -1.3 && phi_[i] > -1.57 && phi_[i] < -0.87) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    };
-
-    return df.Define("HEMVeto", HEMCorrections, {"run", "event", "year", "Jet_pt", "Jet_eta", "Jet_phi", "Jet_jetId"}).Filter("HEMVeto");
-}
-
-/*
-############################################
-MET PHI CORRECTIONS
-############################################
-*/
-
-RNode applyMETPhiCorrections(RNode df, bool isData) {
-    auto eval_correction = [isData] (std::string year, float pt, float phi, unsigned char npvs, unsigned int run) {
-        double pt_corr = pt;
-        double phi_corr = phi;
-        
-        if (metCorrections.find(year) == metCorrections.end()) {
-            static std::unordered_set<std::string> warned_years;
-            if (warned_years.find(year) == warned_years.end()) {
-                std::cout << "Warning: MET correction set for year " << year << " not found. Skipping MET phi corrections." << std::endl;
-                warned_years.insert(year);
-            }
-            return std::make_pair(static_cast<float>(pt_corr), static_cast<float>(phi_corr));
-        }
-
-        std::string pt_corr_name = isData ? "pt_metphicorr_puppimet_data" : "pt_metphicorr_puppimet_mc";
-        std::string phi_corr_name = isData ? "phi_metphicorr_puppimet_data" : "phi_metphicorr_puppimet_mc";
-
-        // Note the correction json is only defined for up to 6500, so do not pass larger values
-        float pt_max = 6499.9;
-        float pt_to_pass = std::min(pt,pt_max);
-        pt_corr = metCorrections.at(year).at(pt_corr_name)->evaluate({pt_to_pass, phi, static_cast<double>(npvs), static_cast<double>(run)});
-        phi_corr = metCorrections.at(year).at(phi_corr_name)->evaluate({pt_to_pass, phi, static_cast<double>(npvs), static_cast<double>(run)});
-        
-        return std::make_pair(static_cast<float>(pt_corr), static_cast<float>(phi_corr));
-    };
-    // Runs AFTER applyType1MET, so it refines the already-rebuilt (met_pt, met_phi) rather than
-    // starting from PuppiMET. Run 3 has no met.json configured (see corrections.h) → no-op there;
-    // the φ correction currently only touches the nominal MET, not the JES-varied copies.
-    return df.Define("_MET_phicorr", eval_correction, {"year", "met_pt", "met_phi", "PV_npvs", "run"})
-            .Redefine("met_pt",  "_MET_phicorr.first")
-            .Redefine("met_phi", "_MET_phicorr.second");
-}
-
-/*
-############################################
-MET UNCLUSTERED CORRECTIONS
-############################################
-*/
-
-RNode applyMETUnclusteredCorrections(RNode df, std::string variation) {
-    if (variation == "up") {
-        return df.Define("_MET_uncert_dx", "met_pt * TMath::Cos(met_phi) + MET_MetUnclustEnUpDeltaX")
-                .Define("_MET_uncert_dy", "met_pt * TMath::Sin(met_phi) + MET_MetUnclustEnUpDeltaY")
-                .Redefine("met_pt", "(float)TMath::Sqrt(_MET_uncert_dx * _MET_uncert_dx + _MET_uncert_dy * _MET_uncert_dy)");
-    }
-
-    else if (variation == "down") {
-        return df.Define("_MET_uncert_dx", "met_pt * TMath::Cos(met_phi) - MET_MetUnclustEnUpDeltaX")
-                .Define("_MET_uncert_dy", "met_pt * TMath::Sin(met_phi) - MET_MetUnclustEnUpDeltaY")
-                .Redefine("met_pt", "(float)TMath::Sqrt(_MET_uncert_dx * _MET_uncert_dx + _MET_uncert_dy * _MET_uncert_dy)");
-    }
-    return df;
-}
-
-/*
-############################################
-JET ENERGY CORRECTIONS — nominal 
-############################################
-
-Recipe (per AK4 jet, year-aware):
-  pt_raw   = (1 - Jet_rawFactor) * Jet_pt     // undo NanoAOD JEC
-  mass_raw = (1 - Jet_rawFactor) * Jet_mass
-
-  factor   = compound(Jet_area, Jet_eta, pt_raw, rho [, Jet_phi] [, run])
-             // compound = L1FastJet * L2Relative * L3Absolute (* L2L3Residual for DATA),
-             // with `inputs_update=[JetPt]` so each stage feeds the next its updated pt.
-             // The 2023BPix + 2024 pinned files also require Jet_phi; evalJECCompound()
-             // appends JetPhi/run only when the file declares them (see below).
-  pt_new   = pt_raw   * factor
-  mass_new = mass_raw * factor
-
-MET is NOT touched here anymore. Type-I MET is rebuilt from RawPuppiMET in applyType1MET()
-(over Jet + CorrT1METJet, with muon subtraction), following the JERC recipe in
-Type1MET.pdf / skimmer getT1CHSMET. See the TYPE-1 PUPPI MET section below.
-
-NanoAOD branches consumed:
-  Jet_pt, Jet_mass, Jet_eta, Jet_phi, Jet_area, Jet_rawFactor,
-  Rho_fixedGridRhoFastjetAll, run, year
+makeCompoundJECName + evalJECCompound serve the nominal AK4/AK8 JEC and the
+Type-1 MET rebuild; evalJERCorrection serves the AK4/AK8 JER smearing and the
+CorrT1METJet JER inside applyType1MET.
 */
 
 namespace {
@@ -240,12 +340,18 @@ namespace {
         return base + (isData ? "_DATA" : "_MC") + "_L1L2L3Res_" + algo;
     }
 
-    // Evaluate a JEC L1L2L3Res compound, building the input vector in the exact order the
-    // file declares it. The pinned 2026-06-05 files added a `JetPhi` input to the
-    // 2023BPix + 2024 compounds (and DATA additionally takes `run`); older eras do not have
-    // it. Querying inputs() keeps a single call correct for every era and future file bumps —
-    // passing a fixed-length arg list silently threw "wrong number of inputs" for 2023BPix/2024,
-    // which the per-jet catch turned into sf=1.0 (jets left at raw pT).
+    // Evaluate a JEC L1L2L3Res compound, building the argument vector by matching each of the
+    // correction's declared inputs() by name. This is deliberate: the compound's input list is
+    // NOT fixed — it varies from era to era, differs between MC and DATA, and can change on a file
+    // re-pin. Hard-coding a fixed-length arg list would silently break the moment a new file adds
+    // or drops an input. Passing arguments by name stays correct across all of those without
+    // touching this function; only a genuinely new input name reaches the `throw` below, which is
+    // a loud, intentional signal to add a mapping (not a silent wrong answer).
+    //
+    // Example of the kind of drift this guards against: the 2026-06-05 files added a `JetPhi` input
+    // to the 2023BPix + 2024 compounds (DATA there also takes `run`), while older eras have neither.
+    // A fixed arg list threw "wrong number of inputs" for those eras, which the per-jet catch turned
+    // into sf=1.0 — jets silently left at raw pT.
     inline double evalJECCompound(const correction::CompoundCorrection& comp,
                                   double area, double eta, double pt, double rho,
                                   double phi, double run) {
@@ -260,16 +366,22 @@ namespace {
             else if (n == "JetPhi") args.push_back(phi);
             else if (n == "run")    args.push_back(run);
             else throw std::runtime_error("JEC compound: unexpected input '" + n
-                                          + "'. corrections.cpp evalJECCompound needs a mapping for it.");
+                                          + "'. corrections.cpp evalJECCompound() needs a mapping for it.");
         }
         return comp.evaluate(args);
     }
 
-    // Evaluate a JER PtResolution / ScaleFactor correction by input name. The pinned
-    // 2026-06-05 files ship the ScaleFactor with inputs [JetEta, JetPt] and NO `systematic`
-    // string (older files had one). The previous size>=3 heuristic mistook that for
-    // [JetEta, systematic] and fed "nom" into the JetPt slot ("wrong type: got string").
-    // `syst` is only used when the correction actually declares a `systematic` input.
+    // Evaluate a JER PtResolution or ScaleFactor correction, building the argument vector by
+    // matching each declared input() by name (same rationale as evalJECCompound above): the input
+    // list is NOT fixed — it differs between the two correction types and can change on a file
+    // re-pin — so position-based argument passing is fragile. Matching by name means one helper
+    // serves both objects and survives file bumps; `syst` is consumed only when the correction
+    // actually declares a `systematic` input (PtResolution does not; the ScaleFactor may or may not).
+    //
+    // Example of the kind of drift this guards against: the 2026-06-05 files ship the ScaleFactor
+    // as [JetEta, JetPt] with NO `systematic`, whereas older files had one. A position-based
+    // heuristic that assumed "3+ inputs ⇒ [JetEta, systematic, ...]" fed "nom" into the JetPt slot
+    // ("wrong type: got string").
     inline double evalJERCorrection(const correction::Correction& c,
                                     double eta, double pt, double rho, const std::string& syst) {
         std::vector<correction::Variable::Type> args;
@@ -281,11 +393,92 @@ namespace {
             else if (n == "Rho")        args.push_back(rho);
             else if (n == "systematic") args.push_back(syst);
             else throw std::runtime_error("JER correction '" + c.name() + "': unexpected input '" + n
-                                          + "'. corrections.cpp evalJERCorrection needs a mapping for it.");
+                                          + "'. corrections.cpp evalJERCorrection() needs a mapping for it.");
         }
         return c.evaluate(args);
     }
+
+    // One jet's JER smear factors {nom, up, dn} via JERSmear. The ±1σ scale factors are
+    // sf ± unc — the pinned files use the split-tag format (JME 2026-06-04 "newJERFormats"):
+    // the ScaleFactor correction has NO `systematic` axis and the symmetric absolute
+    // uncertainty ships as a separate SFUncertainty correction. res, gen_pt, rho and the
+    // event seed are shared by all three evaluations, so the stochastic Gaussian kick is
+    // identical and the variations stay fully correlated with the nominal smearing, per the
+    // JME hybrid recipe. With withVariations=false the up/dn slots repeat the nominal.
+    // Two conventions applied HERE, on top of the raw JERSmear payload:
+    //  1. The 3σ gen-match window (|pt − gen| < 3·res·pt) — the payload does NOT implement
+    //     it (it only branches on the sign of GenPt); the caller must apply it, exactly as
+    //     the JERC tutorial does (JecApplication.cpp::jerFactor). Out-of-window matches are
+    //     demoted to the stochastic branch (gen := −1).
+    //  2. Stochastic-branch seeding: in the payload, for GenPt<0 the JetPt input is used
+    //     ONLY as hashprng seed material (the smear formula itself reads res/sf/N). We pass
+    //     the variation-independent seed_pt (the RAW jet pt) there instead of the corrected
+    //     pt, so the Gaussian draw is IDENTICAL for the nominal and every JES/JER variation
+    //     — otherwise a per-mille pt shift would re-roll the random number and inject O(res)
+    //     noise into the variation templates. (coffea's CorrectedJetsFactory seeds its
+    //     Gaussian from the raw pt for the same reason.) Gen-matched jets keep the true pt
+    //     (their branch is analytic in JetPt; no randomness).
+    inline std::array<double, 3> evalJERSmearNomUpDn(const correction::Correction& smear,
+                                                     double pt, double eta, double gen_pt,
+                                                     double seed_pt,
+                                                     double rho, unsigned long long event,
+                                                     double res, double sf, double unc,
+                                                     bool withVariations) {
+        const bool useGen  = (gen_pt >= 0.0) && (std::abs(pt - gen_pt) < 3.0 * res * pt);
+        const double ptIn  = useGen ? pt : seed_pt;
+        const double genIn = useGen ? gen_pt : -1.0;
+        // The payload formulas are NOT clamped: a very negative Gaussian (or a bad match)
+        // can give a negative factor → negative jet pt. Clamp at 0 ("jet fluctuated away"),
+        // per the JME documentation ("always ≥ 0"; coffea clamps to a minimal jet pt).
+        auto ev = [&](double sfv) {
+            return std::max(0.0, smear.evaluate({ptIn, eta, genIn, rho, (int)event, res, sfv}));
+        };
+        const double nom = ev(sf);
+        if (!withVariations) return {nom, nom, nom};
+        return {nom, ev(sf + unc), ev(sf - unc)};
+    }
+
+    // Per-collection JER smear factors for the nominal and the ±1σ SF variations
+    // (RDF column payload; consumed by the Define chains below and by applyType1MET).
+    struct JERFactors {
+        RVec<float> nom, up, dn;
+    };
+
+    // Resolve the per-jet matched gen pt from a NanoAOD gen index column (−1 if unmatched).
+    inline RVec<float> matchedGenPt(const RVec<short>& idx, const RVec<float>& gpt) {
+        RVec<float> out(idx.size(), -1.0f);
+        for (size_t i = 0; i < idx.size(); ++i)
+            if (idx[i] >= 0 && idx[i] < (int)gpt.size()) out[i] = gpt[idx[i]];
+        return out;
+    }
 }
+
+/*
+############################################
+JET ENERGY CORRECTIONS — nominal
+############################################
+
+Recipe (per AK4 jet, year-aware):
+
+  pt_raw   = (1 - Jet_rawFactor) * Jet_pt     // undo NanoAOD JEC
+  mass_raw = (1 - Jet_rawFactor) * Jet_mass
+  factor   = compound(Jet_area, Jet_eta, pt_raw, rho [, Jet_phi] [, run])
+             // compound = L1FastJet * L2Relative * L3Absolute (* L2L3Residual for DATA),
+             // evaluated internally by correctionlib with `inputs_update=[JetPt]` so each
+             //  stage feeds the next its updated pt. The 2023BPix + 2024 pinned files also
+             // require Jet_phi; evalJECCompound() appends JetPhi/run only when the file
+             // declares them (see above).
+  pt_new   = pt_raw   * factor
+  mass_new = mass_raw * factor
+
+MET is NOT touched here anymore. Type-I MET is rebuilt from RawPuppiMET in applyType1MET()
+(over Jet + CorrT1METJet, with muon subtraction), following the new JERC recipe at
+https://cms-jerc.web.cern.ch/Type1MET/. See the TYPE-1 PUPPI MET section below.
+
+NanoAOD branches consumed:
+  Jet_pt, Jet_mass, Jet_eta, Jet_phi, Jet_area, Jet_rawFactor,
+  Rho_fixedGridRhoFastjetAll, run, year
+*/
 
 RNode applyJetEnergyCorrections(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
                                 const std::unordered_map<std::string, std::string>& jec_prefix_map,
@@ -304,9 +497,9 @@ RNode applyJetEnergyCorrections(const std::unordered_map<std::string, correction
         auto pf_it = jec_prefix_map.find(year);
         auto sf_it = jec_suffix_map.find(year);
         if (cs_it == cset_jerc.end() || pf_it == jec_prefix_map.end() || sf_it == jec_suffix_map.end()) {
-            throw std::runtime_error("AK4 JEC: no correction set / prefix / suffix configured for year '"
+            throw std::runtime_error("AK4 JEC: no correction set, prefix, or suffix configured for year '"
                                      + year + "'. Refusing to run with jets uncorrected — add this year to "
-                                       "the JEC maps in corrections.h.");
+                                       "the JERC era table in corrections.cpp.");
         }
 
         const std::string compound_name = makeCompoundJECName(pf_it->second, sf_it->second, isData);
@@ -316,7 +509,7 @@ RNode applyJetEnergyCorrections(const std::unordered_map<std::string, correction
         } catch (const std::out_of_range&) {
             throw std::runtime_error("AK4 JEC: compound '" + compound_name
                                      + "' not found in the pinned jet_jerc.json.gz for year '" + year
-                                     + "'. The JEC tag string in corrections.h is stale relative to the "
+                                     + "'. The JEC tag in the JERC era table (corrections.cpp) is stale relative to the "
                                        "pinned snapshot (version drift). Refusing to run with jets uncorrected.");
         }
 
@@ -332,8 +525,11 @@ RNode applyJetEnergyCorrections(const std::unordered_map<std::string, correction
                           << ", eta=" << eta[i] << "): " << e.what() << ". Setting SF to 1.0." << std::endl;
                 sf = 1.0;
             }
-            // Multiplicative factor on the *NanoAOD* pt: Jet_pt_new = Jet_pt * factor
-            //   = Jet_pt * (pt_raw / Jet_pt) * sf = (1 - rawFactor) * sf
+            // `sf` corrects the *raw* pt: pt_new = pt_raw * sf. But this column stores a factor
+            // that will be applied to the NanoAOD pt downstream (Jet_pt := Jet_pt * factor), so we
+            // fold in the raw recovery too:
+            //     pt_new = pt_raw * sf = (1 - rawFactor) * Jet_pt * sf
+            //   ⇒ factor = pt_new / Jet_pt = (1 - rawFactor) * sf            
             factor[i] = (1.0f - rawFactor[i]) * static_cast<float>(sf);
         }
         return factor;
@@ -390,9 +586,9 @@ RNode applyFatJetEnergyCorrections(const std::unordered_map<std::string, correct
         auto pf_it = jec_prefix_map.find(year);
         auto sf_it = jec_suffix_map.find(year);
         if (cs_it == cset_jerc.end() || pf_it == jec_prefix_map.end() || sf_it == jec_suffix_map.end()) {
-            throw std::runtime_error("AK8 JEC: no correction set / prefix / suffix configured for year '"
+            throw std::runtime_error("AK8 JEC: no correction set, prefix, or suffix configured for year '"
                                      + year + "'. Refusing to run with fat jets uncorrected — add this year "
-                                       "to the JEC maps in corrections.h.");
+                                       "to the JERC era table in corrections.cpp.");
         }
 
         const std::string compound_name = makeCompoundJECName(pf_it->second, sf_it->second, isData);
@@ -402,7 +598,7 @@ RNode applyFatJetEnergyCorrections(const std::unordered_map<std::string, correct
         } catch (const std::out_of_range&) {
             throw std::runtime_error("AK8 JEC: compound '" + compound_name
                                      + "' not found in the pinned fatJet_jerc.json.gz for year '" + year
-                                     + "'. The JEC tag string in corrections.h is stale relative to the "
+                                     + "'. The JEC tag in the JERC era table (corrections.cpp) is stale relative to the "
                                        "pinned snapshot (version drift). Refusing to run with fat jets uncorrected.");
         }
 
@@ -444,18 +640,240 @@ RNode applyFatJetEnergyCorrections(const std::unordered_map<std::string, correct
 
 /*
 ############################################
+JET ENERGY RESOLUTION — hybrid smearing (MC only)
+############################################
+
+Per AK4 jet (using the JEC-corrected pt that this function consumes):
+  res = PtResolution(eta, pt, rho)                        // relative resolution
+  sf  = ScaleFactor(eta, pt)                              // data/MC width ratio
+  unc = SFUncertainty(eta, pt)                            // symmetric ±1σ on sf (split-tag format)
+  pt_smear[nom|up|dn] = JERSmear(pt, eta, gen_pt_or_-1, rho, event, res, sf | sf±unc)
+               // hybrid: scaling when |pt - pt_gen| < 3*res*pt and gen-matched (genJetIdx>=0),
+               // stochastic Gaussian otherwise (same seed for nom/up/dn → fully correlated).
+               // Always >= 0.
+  pt_new   = pt * pt_smear ; mass_new = mass * pt_smear
+
+Output columns:
+  Jet_jerFactor                              nominal smear factor (consumed by applyType1MET)
+  Jet_pt / Jet_mass                          redefined to the nominal-smeared values
+  with storeVariations (MC + systematics):
+  Jet_jerFactor_jerUp / _jerDn               ±1σ smear factors (consumed by applyType1MET)
+  Jet_pt_jerUp/Dn, Jet_mass_jerUp/Dn         ±1σ kinematics, built from the same pre-smear
+                                             (JEC-corrected) pt/mass as the nominal
+*/
+
+RNode applyJetEnergyResolution(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
+                               const std::unordered_map<std::string, correction::CorrectionSet>& cset_jer_smear,
+                               const std::unordered_map<std::string, std::string>& jer_res_map,
+                               const std::unordered_map<std::string, std::string>& jer_sf_map,
+                               const std::unordered_map<std::string, std::string>& jer_unc_map,
+                               RNode df, bool storeVariations) {
+
+    auto compute_smear = [cset_jerc, cset_jer_smear, jer_res_map, jer_sf_map, jer_unc_map,
+                          storeVariations](
+            std::string year,
+            RVec<float> pt, RVec<float> eta,
+            RVec<short> genJet_idx, RVec<float> genJet_pt, RVec<float> seedpt,
+            float rho, unsigned long long event) {
+
+        JERFactors f;
+        f.nom.assign(pt.size(), 1.0f);
+        f.up.assign(pt.size(), 1.0f);
+        f.dn.assign(pt.size(), 1.0f);
+        if (pt.empty()) return f;
+
+        auto cs_it = cset_jerc.find(year);
+        auto sm_it = cset_jer_smear.find("jer_smear");
+        auto rn_it = jer_res_map.find(year);
+        auto sn_it = jer_sf_map.find(year);
+        auto un_it = jer_unc_map.find(year);
+        if (cs_it == cset_jerc.end() || sm_it == cset_jer_smear.end()
+            || rn_it == jer_res_map.end() || sn_it == jer_sf_map.end()
+            || un_it == jer_unc_map.end()) {
+            throw std::runtime_error("AK4 JER: resolution, SF, SF-uncertainty, or smear inputs not "
+                                     "configured for year '" + year + "'. Refusing to run with jets "
+                                     "un-smeared — add this year to the JERC era table in corrections.cpp.");
+        }
+
+        std::shared_ptr<const correction::Correction> res, sf, unc, smear;
+        try {
+            res   = cs_it->second.at(rn_it->second);
+            sf    = cs_it->second.at(sn_it->second);
+            unc   = cs_it->second.at(un_it->second);
+            smear = sm_it->second.at("JERSmear");
+        } catch (const std::out_of_range&) {
+            throw std::runtime_error("AK4 JER: a res/sf/unc key (res='" + rn_it->second + "', sf='"
+                                     + sn_it->second + "', unc='" + un_it->second
+                                     + "') was not found in the pinned jet_jerc.json.gz for year '" + year
+                                     + "'. The JER tag in the JERC era table (corrections.cpp) is stale relative to the pinned "
+                                       "snapshot (version drift). Refusing to run with jets un-smeared.");
+        }
+
+        for (size_t i = 0; i < pt.size(); ++i) {
+            const float gen_pt = (genJet_idx[i] >= 0 && genJet_idx[i] < (int)genJet_pt.size())
+                                     ? genJet_pt[genJet_idx[i]] : -1.0f;
+            const double r = evalJERCorrection(*res, (double)eta[i], (double)pt[i], (double)rho, "nom");
+            const double s = evalJERCorrection(*sf,  (double)eta[i], (double)pt[i], (double)rho, "nom");
+            const double u = storeVariations
+                                 ? evalJERCorrection(*unc, (double)eta[i], (double)pt[i], (double)rho, "nom")
+                                 : 0.0;
+            const auto sm = evalJERSmearNomUpDn(*smear, (double)pt[i], (double)eta[i], (double)gen_pt,
+                                                (double)seedpt[i],
+                                                (double)rho, event, r, s, u, storeVariations);
+            f.nom[i] = static_cast<float>(sm[0]);
+            f.up[i]  = static_cast<float>(sm[1]);
+            f.dn[i]  = static_cast<float>(sm[2]);
+        }
+        return f;
+    };
+
+    // NOTE: MET is no longer propagated here. Jet_jerFactor (and the up/dn factors) are
+    // consumed by applyType1MET(), which folds JEC*JER into the per-jet correction when
+    // rebuilding the Type-I MET from RawPuppiMET. This function only smears the jets.
+    // Snapshots of the pre-smear (JEC-corrected) state + matched gen pt: consumed by
+    // defineJESVariation, which evaluates the JES shift on the JEC pt and re-applies
+    // JER on the shifted pt (official JERC ordering: JES variations BEFORE smearing).
+    df = df.Define("_Jet_genpt", matchedGenPt, {"Jet_genJetIdx", "GenJet_pt"})
+           .Define("_Jet_pt_prejer",   "Jet_pt")
+           .Define("_Jet_mass_prejer", "Jet_mass")
+           // Variation-independent PRNG seed for the stochastic branch: the raw pt
+           // (rawFactor is kept self-consistent by the JEC step, so this is the NanoAOD raw pt).
+           .Define("_Jet_seedpt", "(1.0f - Jet_rawFactor) * Jet_pt");
+    df = df.Define("_Jet_jerFactors", compute_smear,
+                   {"year", "Jet_pt", "Jet_eta", "Jet_genJetIdx", "GenJet_pt", "_Jet_seedpt",
+                    "Rho_fixedGridRhoFastjetAll", "event"});
+    df = df.Define("Jet_jerFactor", [](const JERFactors& f) { return f.nom; }, {"_Jet_jerFactors"});
+    if (storeVariations) {
+        // The pt/mass Defines below run before the nominal Redefine, so they read the
+        // pre-smear (JEC-corrected) kinematics — same baseline as the nominal smearing.
+        df = df.Define("Jet_jerFactor_jerUp", [](const JERFactors& f) { return f.up; }, {"_Jet_jerFactors"})
+               .Define("Jet_jerFactor_jerDn", [](const JERFactors& f) { return f.dn; }, {"_Jet_jerFactors"})
+               .Define("Jet_pt_jerUp",   "Jet_pt   * Jet_jerFactor_jerUp")
+               .Define("Jet_mass_jerUp", "Jet_mass * Jet_jerFactor_jerUp")
+               .Define("Jet_pt_jerDn",   "Jet_pt   * Jet_jerFactor_jerDn")
+               .Define("Jet_mass_jerDn", "Jet_mass * Jet_jerFactor_jerDn");
+    }
+    return df
+        .Redefine("Jet_pt",   "Jet_pt   * Jet_jerFactor")
+        .Redefine("Jet_mass", "Jet_mass * Jet_jerFactor");
+}
+
+/*
+############################################
+FAT JET (AK8) ENERGY RESOLUTION — hybrid smearing (MC only)
+############################################
+
+Same recipe as AK4 (incl. the jerUp/jerDn variation columns) but reading FatJet_* +
+GenJetAK8_* and the AK8PFPuppi resolution/SF/SFUncertainty keys. Does NOT propagate
+to MET (Type-I MET is built from AK4 only).
+*/
+
+RNode applyFatJetEnergyResolution(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
+                                  const std::unordered_map<std::string, correction::CorrectionSet>& cset_jer_smear,
+                                  const std::unordered_map<std::string, std::string>& jer_res_map,
+                                  const std::unordered_map<std::string, std::string>& jer_sf_map,
+                                  const std::unordered_map<std::string, std::string>& jer_unc_map,
+                                  RNode df, bool storeVariations) {
+
+    auto compute_smear = [cset_jerc, cset_jer_smear, jer_res_map, jer_sf_map, jer_unc_map,
+                          storeVariations](
+            std::string year,
+            RVec<float> pt, RVec<float> eta,
+            RVec<short> genJet_idx, RVec<float> genJet_pt, RVec<float> seedpt,
+            float rho, unsigned long long event) {
+
+        JERFactors f;
+        f.nom.assign(pt.size(), 1.0f);
+        f.up.assign(pt.size(), 1.0f);
+        f.dn.assign(pt.size(), 1.0f);
+        if (pt.empty()) return f;
+
+        auto cs_it = cset_jerc.find(year);
+        auto sm_it = cset_jer_smear.find("jer_smear");
+        auto rn_it = jer_res_map.find(year);
+        auto sn_it = jer_sf_map.find(year);
+        auto un_it = jer_unc_map.find(year);
+        if (cs_it == cset_jerc.end() || sm_it == cset_jer_smear.end()
+            || rn_it == jer_res_map.end() || sn_it == jer_sf_map.end()
+            || un_it == jer_unc_map.end()) {
+            throw std::runtime_error("AK8 JER: resolution, SF, SF-uncertainty, or smear inputs not "
+                                     "configured for year '" + year + "'. Refusing to run with fat jets "
+                                     "un-smeared — add this year to the JERC era table in corrections.cpp.");
+        }
+
+        std::shared_ptr<const correction::Correction> res, sf, unc, smear;
+        try {
+            res   = cs_it->second.at(rn_it->second);
+            sf    = cs_it->second.at(sn_it->second);
+            unc   = cs_it->second.at(un_it->second);
+            smear = sm_it->second.at("JERSmear");
+        } catch (const std::out_of_range&) {
+            throw std::runtime_error("AK8 JER: a res/sf/unc key (res='" + rn_it->second + "', sf='"
+                                     + sn_it->second + "', unc='" + un_it->second
+                                     + "') was not found in the pinned fatJet_jerc.json.gz for year '" + year
+                                     + "'. The JER tag in the JERC era table (corrections.cpp) is stale relative to the pinned "
+                                       "snapshot (version drift). Refusing to run with fat jets un-smeared.");
+        }
+
+        for (size_t i = 0; i < pt.size(); ++i) {
+            const float gen_pt = (genJet_idx[i] >= 0 && genJet_idx[i] < (int)genJet_pt.size())
+                                     ? genJet_pt[genJet_idx[i]] : -1.0f;
+            const double r = evalJERCorrection(*res, (double)eta[i], (double)pt[i], (double)rho, "nom");
+            const double s = evalJERCorrection(*sf,  (double)eta[i], (double)pt[i], (double)rho, "nom");
+            const double u = storeVariations
+                                 ? evalJERCorrection(*unc, (double)eta[i], (double)pt[i], (double)rho, "nom")
+                                 : 0.0;
+            const auto sm = evalJERSmearNomUpDn(*smear, (double)pt[i], (double)eta[i], (double)gen_pt,
+                                                (double)seedpt[i],
+                                                (double)rho, event, r, s, u, storeVariations);
+            f.nom[i] = static_cast<float>(sm[0]);
+            f.up[i]  = static_cast<float>(sm[1]);
+            f.dn[i]  = static_cast<float>(sm[2]);
+        }
+        return f;
+    };
+
+    // Pre-smear snapshots + matched gen pt for defineJESVariation (see AK4 comment).
+    df = df.Define("_FatJet_genpt", matchedGenPt, {"FatJet_genJetAK8Idx", "GenJetAK8_pt"})
+           .Define("_FatJet_pt_prejer",   "FatJet_pt")
+           .Define("_FatJet_mass_prejer", "FatJet_mass")
+           .Define("_FatJet_seedpt", "(1.0f - FatJet_rawFactor) * FatJet_pt");
+    df = df.Define("_FatJet_jerFactors", compute_smear,
+                   {"year", "FatJet_pt", "FatJet_eta", "FatJet_genJetAK8Idx", "GenJetAK8_pt",
+                    "_FatJet_seedpt", "Rho_fixedGridRhoFastjetAll", "event"});
+    df = df.Define("FatJet_jerFactor", [](const JERFactors& f) { return f.nom; }, {"_FatJet_jerFactors"});
+    if (storeVariations) {
+        // Defined before the nominal Redefine → built from the pre-smear (JEC) kinematics.
+        df = df.Define("FatJet_jerFactor_jerUp", [](const JERFactors& f) { return f.up; }, {"_FatJet_jerFactors"})
+               .Define("FatJet_jerFactor_jerDn", [](const JERFactors& f) { return f.dn; }, {"_FatJet_jerFactors"})
+               .Define("FatJet_pt_jerUp",   "FatJet_pt   * FatJet_jerFactor_jerUp")
+               .Define("FatJet_mass_jerUp", "FatJet_mass * FatJet_jerFactor_jerUp")
+               .Define("FatJet_pt_jerDn",   "FatJet_pt   * FatJet_jerFactor_jerDn")
+               .Define("FatJet_mass_jerDn", "FatJet_mass * FatJet_jerFactor_jerDn");
+    }
+    return df
+        .Redefine("FatJet_pt",   "FatJet_pt   * FatJet_jerFactor")
+        .Redefine("FatJet_mass", "FatJet_mass * FatJet_jerFactor");
+}
+
+/*
+############################################
 JET ENERGY SCALE — per-source uncertainties (up/down) into suffixed columns
 ############################################
 
-Per-source JES uncertainty applied as a multiplicative shift on top of the nominal JEC.
-Run *after* applyJetEnergyCorrections / applyFatJetEnergyCorrections. Each call writes
-one set of suffixed columns; the driver applyJESVariations loops over the 11 Regrouped V2
+Per-source JES uncertainty following the official JERC ordering: the shift (1 ± u) is
+applied to the JEC-corrected (PRE-smearing) pt, with u(eta, pt) looked up at that JEC pt,
+and JER is then RE-EVALUATED on the shifted pt (same event seed as the nominal smearing,
+so the variation stays fully correlated). Run *after* applyJet/FatJetEnergyCorrections +
+apply*EnergyResolution (it consumes the _<coll>_{pt,mass}_prejer / _<coll>_genpt
+snapshots those define). The driver applyJESVariations loops over the 11 Regrouped V2
 sources × {Up, Dn} = 22 variations.
 
-  AK4: Jet_pt_<sfx>, Jet_mass_<sfx>, _Jet_shift_<sfx>   (per-jet shift; MET built in applyType1MET)
-  AK8: FatJet_pt_<sfx>, FatJet_mass_<sfx>               (FatJet_msoftdrop has its own JEC recipe)
-  The matching met_pt_<sfx> / met_phi_<sfx> are produced by applyType1MET, which reads
-  _Jet_shift_<sfx> and rebuilds the Type-I MET from RawPuppiMET for that variation.
+  Per jet:  pt_<sfx> = pt_JEC · (1 ± u(eta, pt_JEC)) · c_JER(pt_JEC·(1±u))
+
+  AK4: Jet_pt_<sfx>, Jet_mass_<sfx>, _Jet_var_<sfx>  (full per-jet variation factor
+       relative to the JEC pt; consumed by applyType1MET for the per-variation MET)
+  AK8: FatJet_pt_<sfx>, FatJet_mass_<sfx>            (FatJet_msoftdrop has its own JEC recipe)
   <sfx> = "jes" + column_label + direction   e.g. "jesAbsoluteUp", "jesAbsoluteYearDn"
 
 Source list lives in kJESRegroupedSources below. Lookup keys in jet_jerc.json.gz are
@@ -465,25 +883,41 @@ decorrelated (e.g. Regrouped_Absolute_2018 vs the year-correlated Regrouped_Abso
 */
 
 namespace {
-// Returns a closure giving per-jet shift factors (1 + sign*u) for use with RDF::Define.
-auto makeJESShiftEvaluator(
+// Returns a closure giving the per-jet FULL variation factor relative to the JEC
+// (pre-smear) pt:  v = (1 + sign·u(eta, pt)) · c_JER(pt·(1+sign·u))
+// i.e. JES shift first, then JER smearing re-evaluated at the shifted pt (res, sf and
+// the JERSmear gen-match window all see the shifted pt), per the JERC tutorial's
+// ordering (JecApplication.cpp::correctedMet). The event seed is shared with the
+// nominal smearing, so the stochastic kick is identical and the variation stays fully
+// correlated. `gen_pt` is the per-jet matched gen pt (−1 if unmatched).
+auto makeJESVarEvaluator(
         const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
         const std::unordered_map<std::string, std::string>& jec_prefix_map,
         const std::unordered_map<std::string, std::string>& jec_suffix_map,
         const std::unordered_map<std::string, std::string>& year_token_map,
+        const std::unordered_map<std::string, std::string>& jer_res_map,
+        const std::unordered_map<std::string, std::string>& jer_sf_map,
+        const std::unordered_map<std::string, correction::CorrectionSet>& cset_jer_smear,
         std::string base_source, bool yearDecorrelated, float sign) {
     return [cset_jerc, jec_prefix_map, jec_suffix_map, year_token_map,
+            jer_res_map, jer_sf_map, cset_jer_smear,
             base_source, yearDecorrelated, sign](
-            std::string year, RVec<float> pt, RVec<float> eta) {
+            std::string year, RVec<float> pt, RVec<float> eta, RVec<float> gen_pt,
+            RVec<float> seed_pt, float rho, unsigned long long event) {
         RVec<float> out(pt.size(), 1.0f);
         if (pt.empty()) return out;
         auto cs_it = cset_jerc.find(year);
         auto pf_it = jec_prefix_map.find(year);
         auto sf_it = jec_suffix_map.find(year);
-        if (cs_it == cset_jerc.end() || pf_it == jec_prefix_map.end() || sf_it == jec_suffix_map.end()) {
-            throw std::runtime_error("JES uncertainty: no correction set / prefix / suffix configured for "
-                                     "year '" + year + "' (source '" + base_source + "'). Refusing to emit "
-                                     "an empty JES variation — add this year to the JEC maps in corrections.h.");
+        auto rn_it = jer_res_map.find(year);
+        auto sn_it = jer_sf_map.find(year);
+        auto sm_it = cset_jer_smear.find("jer_smear");
+        if (cs_it == cset_jerc.end() || pf_it == jec_prefix_map.end() || sf_it == jec_suffix_map.end()
+            || rn_it == jer_res_map.end() || sn_it == jer_sf_map.end() || sm_it == cset_jer_smear.end()) {
+            throw std::runtime_error("JES uncertainty: correction set / prefix / suffix / JER inputs not "
+                                     "configured for year '" + year + "' (source '" + base_source + "'). "
+                                     "Refusing to emit an empty JES variation — add this year to the JERC "
+                                     "era table in corrections.cpp.");
         }
         std::string src = base_source;
         if (yearDecorrelated) {
@@ -491,76 +925,80 @@ auto makeJESShiftEvaluator(
             if (yt_it == year_token_map.end()) {
                 throw std::runtime_error("JES uncertainty: no year token configured for year '" + year
                                          + "' (needed for year-decorrelated source '" + base_source
-                                         + "'). Add it to jetEnergyCorrections_yearToken in corrections.h.");
+                                         + "'). Add it to the JERC era table in corrections.cpp.");
             }
             src += "_" + yt_it->second;
         }
         const std::string unc_name = pf_it->second + "_" + src + "_" + sf_it->second;
-        std::shared_ptr<const correction::Correction> unc;
+        std::shared_ptr<const correction::Correction> unc, res, sf, smear;
         try {
-            unc = cs_it->second.at(unc_name);
+            unc   = cs_it->second.at(unc_name);
+            res   = cs_it->second.at(rn_it->second);
+            sf    = cs_it->second.at(sn_it->second);
+            smear = sm_it->second.at("JERSmear");
         } catch (const std::out_of_range&) {
             throw std::runtime_error("JES uncertainty: source '" + unc_name
-                                     + "' not found in the pinned jerc file for year '" + year
-                                     + "'. The JEC tag string in corrections.h is stale relative to the "
+                                     + "' (or its JER res/sf partners) not found in the pinned jerc file "
+                                       "for year '" + year
+                                     + "'. The JEC tag in the JERC era table (corrections.cpp) is stale relative to the "
                                        "pinned snapshot (version drift). Refusing to emit an empty variation.");
         }
         for (size_t i = 0; i < pt.size(); ++i) {
-            float u = unc->evaluate({(double)eta[i], (double)pt[i]});
-            out[i] = 1.0f + sign * u;
+            const double u  = unc->evaluate({(double)eta[i], (double)pt[i]});
+            const double s  = 1.0 + (double)sign * u;
+            const double ptS = (double)pt[i] * s;
+            const double r   = evalJERCorrection(*res, (double)eta[i], ptS, (double)rho, "nom");
+            const double sfv = evalJERCorrection(*sf,  (double)eta[i], ptS, (double)rho, "nom");
+            // Window + raw-pt stochastic seeding handled by the helper (same seed as the
+            // nominal smearing → same Gaussian → variation fully correlated).
+            const auto sm = evalJERSmearNomUpDn(*smear, ptS, (double)eta[i], (double)gen_pt[i],
+                                                (double)seed_pt[i], (double)rho, event,
+                                                r, sfv, 0.0, false);
+            out[i] = static_cast<float>(s * sm[0]);
         }
         return out;
     };
 }
 
-} // anonymous namespace
-
-RNode defineAK4JESVariation(
-        const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
-        const std::unordered_map<std::string, std::string>& jec_prefix_map,
-        const std::unordered_map<std::string, std::string>& jec_suffix_map,
-        const std::unordered_map<std::string, std::string>& year_token_map,
-        RNode df, const std::string& column_label, const std::string& base_source,
-        bool yearDecorrelated, const std::string& direction) {
+// Defines one JES variation for one collection ("Jet" or "FatJet"): the per-jet full
+// variation factor _<collection>_var_<sfx> (relative to the pre-smear JEC pt) and the
+// varied <collection>_pt_<sfx> / <collection>_mass_<sfx>, built from the pre-smear
+// snapshots (_<coll>_{pt,mass}_prejer, _<coll>_genpt) taken in apply*EnergyResolution.
+// The correction set and algo suffix are looked up in the registry from the collection
+// name; AK4 and AK8 share the same JEC release (prefix) and year tokens, so the JES
+// sources are correlated between the two algorithms per the JERC prescription.
+//
+// For the main jets, the matching met_pt_<sfx> / met_phi_<sfx> are built in
+// applyType1MET(), which reads _Jet_var_<sfx> and rebuilds the Type-I MET from
+// RawPuppiMET for this variation. (NOT FatJet_msoftdrop — that has its own JEC recipe;
+// AK8 does not enter the Type-I MET, which is built from AK4 only.)
+RNode defineJESVariation(RNode df, const std::string& collection,
+                         const std::string& column_label, const std::string& base_source,
+                         bool yearDecorrelated, const std::string& direction) {
     if (direction != "Up" && direction != "Dn") return df;
+    const bool isFat = (collection == "FatJet");
     const float sign = (direction == "Up") ? +1.0f : -1.0f;
     const std::string sfx = "jes" + column_label + direction;
-    const std::string shiftCol = "_Jet_shift_" + sfx;
+    const std::string varCol = "_" + collection + "_var_" + sfx;
 
-    auto eval_factor = makeJESShiftEvaluator(cset_jerc, jec_prefix_map, jec_suffix_map,
-                                             year_token_map, base_source, yearDecorrelated, sign);
+    auto eval_factor = makeJESVarEvaluator(
+        isFat ? fatJetEnergyCorrections() : jetEnergyCorrections(),
+        jetEnergyCorrections_JEC_prefix(),   // same JEC release for AK4 and AK8
+        isFat ? fatJetEnergyCorrections_JEC_suffix() : jetEnergyCorrections_JEC_suffix(),
+        jetEnergyCorrections_yearToken(),
+        isFat ? fatJetEnergyResolution_JER_res_name() : jetEnergyResolution_JER_res_name(),
+        isFat ? fatJetEnergyResolution_JER_sf_name()  : jetEnergyResolution_JER_sf_name(),
+        jetEnergyResolution_smear(),
+        base_source, yearDecorrelated, sign);
 
-    // Writes the per-jet shift factor (_Jet_shift_<sfx>) and the shifted Jet kinematics.
-    // The matching met_pt_<sfx> / met_phi_<sfx> are built in applyType1MET(), which reads
-    // _Jet_shift_<sfx> and rebuilds the Type-I MET from RawPuppiMET for this variation.
+    const std::string pre = "_" + collection;
     return df
-        .Define(shiftCol, eval_factor, {"year", "Jet_pt", "Jet_eta"})
-        .Define("Jet_pt_"   + sfx, "Jet_pt   * " + shiftCol)
-        .Define("Jet_mass_" + sfx, "Jet_mass * " + shiftCol);
+        .Define(varCol, eval_factor,
+                {"year", pre + "_pt_prejer", collection + "_eta", pre + "_genpt",
+                 pre + "_seedpt", "Rho_fixedGridRhoFastjetAll", "event"})
+        .Define(collection + "_pt_"   + sfx, pre + "_pt_prejer   * " + varCol)
+        .Define(collection + "_mass_" + sfx, pre + "_mass_prejer * " + varCol);
 }
-
-RNode defineFatJetJESVariation(
-        const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
-        const std::unordered_map<std::string, std::string>& jec_prefix_map,
-        const std::unordered_map<std::string, std::string>& jec_suffix_map,
-        const std::unordered_map<std::string, std::string>& year_token_map,
-        RNode df, const std::string& column_label, const std::string& base_source,
-        bool yearDecorrelated, const std::string& direction) {
-    if (direction != "Up" && direction != "Dn") return df;
-    const float sign = (direction == "Up") ? +1.0f : -1.0f;
-    const std::string sfx = "jes" + column_label + direction;
-    const std::string shiftCol = "_FatJet_shift_" + sfx;
-
-    auto eval_factor = makeJESShiftEvaluator(cset_jerc, jec_prefix_map, jec_suffix_map,
-                                             year_token_map, base_source, yearDecorrelated, sign);
-
-    return df
-        .Define(shiftCol, eval_factor, {"year", "FatJet_pt", "FatJet_eta"})
-        .Define("FatJet_pt_"   + sfx, "FatJet_pt   * " + shiftCol)
-        .Define("FatJet_mass_" + sfx, "FatJet_mass * " + shiftCol);
-}
-
-namespace {
 struct JESSourceSpec {
     const char* label;          // column-name suffix, e.g. "Absolute" or "AbsoluteYear"
     const char* base_source;    // JEC source key root, e.g. "Regrouped_Absolute"
@@ -588,18 +1026,8 @@ static const std::array<const char*, 2> kJESDirections = {"Up", "Dn"};
 RNode applyJESVariations(RNode df) {
     for (const auto& src : kJESRegroupedSources) {
         for (const char* dir : kJESDirections) {
-            df = defineAK4JESVariation(
-                jetEnergyCorrections,
-                jetEnergyCorrections_JEC_prefix,
-                jetEnergyCorrections_JEC_suffix,
-                jetEnergyCorrections_yearToken,
-                df, src.label, src.base_source, src.yearDecorrelated, dir);
-            df = defineFatJetJESVariation(
-                fatJetEnergyCorrections,
-                fatJetEnergyCorrections_JEC_prefix,
-                fatJetEnergyCorrections_JEC_suffix,
-                jetEnergyCorrections_yearToken,
-                df, src.label, src.base_source, src.yearDecorrelated, dir);
+            df = defineJESVariation(df, "Jet",    src.label, src.base_source, src.yearDecorrelated, dir);
+            df = defineJESVariation(df, "FatJet", src.label, src.base_source, src.yearDecorrelated, dir);
         }
     }
     return df;
@@ -617,6 +1045,18 @@ std::vector<std::string> jesVariationSuffixes() {
             out.push_back(std::string("jes") + src.label + dir);
         }
     }
+    return out;
+}
+
+std::vector<std::string> jerVariationSuffixes() {
+    if (!g_storeSysts) return {};
+    return {"jerUp", "jerDn"};
+}
+
+std::vector<std::string> kinematicVariationSuffixes() {
+    auto out = jesVariationSuffixes();
+    auto jer = jerVariationSuffixes();
+    out.insert(out.end(), jer.begin(), jer.end());
     return out;
 }
 
@@ -691,6 +1131,8 @@ RNode applyType1MET(RNode df, bool isData) {
     // Tolerate optional / MC-only branches.
     df = aliasOrFill(df, "_t1_jet_musubDphi", "Jet_muonSubtrDeltaPhi",          "Jet_eta",          0.0f);
     df = aliasOrFill(df, "_t1_jer",           "Jet_jerFactor",                  "Jet_eta",          1.0f);
+    df = aliasOrFill(df, "_t1_jer_jerUp",     "Jet_jerFactor_jerUp",            "Jet_eta",          1.0f);
+    df = aliasOrFill(df, "_t1_jer_jerDn",     "Jet_jerFactor_jerDn",            "Jet_eta",          1.0f);
     df = aliasOrFill(df, "_t1_ct1_musubDphi", "CorrT1METJet_muonSubtrDeltaPhi", "CorrT1METJet_eta", 0.0f);
     df = aliasOrFill(df, "_t1_ct1_EmEF",      "CorrT1METJet_EmEF",              "CorrT1METJet_eta", 0.0f);
     // Single EM-fraction column so the block builder is shared with CorrT1METJet.
@@ -708,9 +1150,9 @@ RNode applyType1MET(RNode df, bool isData) {
         b.rmpx.resize(n); b.rmpy.resize(n); b.corrjec.resize(n);
         b.rawmusubpt.resize(n); b.pass.resize(n);
         if (n == 0) return b;
-        const auto& cs = jetEnergyCorrections.at(year);
-        const std::string cname = makeCompoundJECName(jetEnergyCorrections_JEC_prefix.at(year),
-                                                      jetEnergyCorrections_JEC_suffix.at(year), isData);
+        const auto& cs = jetEnergyCorrections().at(year);
+        const std::string cname = makeCompoundJECName(jetEnergyCorrections_JEC_prefix().at(year),
+                                                      jetEnergyCorrections_JEC_suffix().at(year), isData);
         auto comp = cs.compound().at(cname);
         for (size_t i = 0; i < n; ++i) {
             const double rawmusubpt = (double)rawpt[i] * (1.0 - (double)musubF[i]);
@@ -753,23 +1195,29 @@ RNode applyType1MET(RNode df, bool isData) {
     df = df.Define("_t1_ct1_ones", ones_like, {"_t1_ct1_blocks"});
 
     // --- CorrT1METJet JER: gen-matched (ΔR<0.2 to GenJet) JERSmear on the JEC musub pt -----
-    // (main-jet JER is the analysis Jet_jerFactor, already in _t1_jer). Data → ones.
+    // (main-jet JER is the analysis Jet_jerFactor, already in _t1_jer). Same nom/up/dn
+    // triplet as the main jets (sf ± SFUncertainty, shared seed). Data → ones.
     if (!isData) {
-        auto build_ct1_jer = [](std::string year, const T1JetBlocks& b,
+        const bool storeVariations = g_storeSysts;
+        auto build_ct1_jer = [storeVariations](std::string year, const T1JetBlocks& b,
                                 const RVec<float>& eta, const RVec<float>& phi,
                                 const RVec<float>& gpt, const RVec<float>& geta, const RVec<float>& gphi,
                                 float rho, unsigned long long event) {
-            RVec<float> jer(b.corrjec.size(), 1.0f);
-            if (b.corrjec.empty()) return jer;
-            std::shared_ptr<const correction::Correction> res, sf;
+            JERFactors f;
+            f.nom.assign(b.corrjec.size(), 1.0f);
+            f.up.assign(b.corrjec.size(), 1.0f);
+            f.dn.assign(b.corrjec.size(), 1.0f);
+            if (b.corrjec.empty()) return f;
+            std::shared_ptr<const correction::Correction> res, sf, unc;
             std::shared_ptr<const correction::Correction> smear;
             try {
-                res   = jetEnergyCorrections.at(year).at(jetEnergyResolution_JER_res_name.at(year));
-                sf    = jetEnergyCorrections.at(year).at(jetEnergyResolution_JER_sf_name.at(year));
-                smear = jetEnergyResolution_smear.at("jer_smear").at("JERSmear");
+                res   = jetEnergyCorrections().at(year).at(jetEnergyResolution_JER_res_name().at(year));
+                sf    = jetEnergyCorrections().at(year).at(jetEnergyResolution_JER_sf_name().at(year));
+                unc   = jetEnergyCorrections().at(year).at(jetEnergyResolution_JER_unc_name().at(year));
+                smear = jetEnergyResolution_smear().at("jer_smear").at("JERSmear");
             } catch (const std::out_of_range&) {
-                throw std::runtime_error("CorrT1METJet JER: res/sf/smear key missing for year '" + year
-                                         + "'. Stale JER tag vs pinned snapshot (see corrections.h).");
+                throw std::runtime_error("CorrT1METJet JER: res/sf/unc/smear key missing for year '" + year
+                                         + "'. Stale JER tag vs pinned snapshot (see the JERC era table in corrections.cpp).");
             }
             for (size_t i = 0; i < b.corrjec.size(); ++i) {
                 const double pt_jec = b.rawmusubpt[i] * b.corrjec[i];   // JEC-corrected musub pt
@@ -782,44 +1230,88 @@ RNode applyType1MET(RNode df, bool isData) {
                     const double dr2  = deta * deta + dphi * dphi;
                     if (dr2 < best) { best = dr2; gen_pt = gpt[g]; }
                 }
-                const double r  = evalJERCorrection(*res, (double)eta[i], pt_jec, (double)rho, "nom");
-                const double s  = evalJERCorrection(*sf,  (double)eta[i], pt_jec, (double)rho, "nom");
-                const double sm = smear->evaluate({pt_jec, (double)eta[i], (double)gen_pt,
-                                                   (double)rho, (int)event, r, s});
-                jer[i] = static_cast<float>(sm);
+                const double r = evalJERCorrection(*res, (double)eta[i], pt_jec, (double)rho, "nom");
+                const double s = evalJERCorrection(*sf,  (double)eta[i], pt_jec, (double)rho, "nom");
+                const double u = storeVariations
+                                     ? evalJERCorrection(*unc, (double)eta[i], pt_jec, (double)rho, "nom")
+                                     : 0.0;
+                const auto sm = evalJERSmearNomUpDn(*smear, pt_jec, (double)eta[i], (double)gen_pt,
+                                                    b.rawmusubpt[i],
+                                                    (double)rho, event, r, s, u, storeVariations);
+                f.nom[i] = static_cast<float>(sm[0]);
+                f.up[i]  = static_cast<float>(sm[1]);
+                f.dn[i]  = static_cast<float>(sm[2]);
             }
-            return jer;
+            return f;
         };
-        df = df.Define("_t1_ct1_jer", build_ct1_jer,
+        df = df.Define("_t1_ct1_jerFactors", build_ct1_jer,
                        {"year", "_t1_ct1_blocks", "CorrT1METJet_eta", "CorrT1METJet_phi",
                         "GenJet_pt", "GenJet_eta", "GenJet_phi", "Rho_fixedGridRhoFastjetAll", "event"});
+        df = df.Define("_t1_ct1_jer", [](const JERFactors& f) { return f.nom; }, {"_t1_ct1_jerFactors"});
+        if (g_storeSysts) {
+            df = df.Define("_t1_ct1_jer_jerUp", [](const JERFactors& f) { return f.up; }, {"_t1_ct1_jerFactors"})
+                   .Define("_t1_ct1_jer_jerDn", [](const JERFactors& f) { return f.dn; }, {"_t1_ct1_jerFactors"});
+        }
     } else {
         df = df.Alias("_t1_ct1_jer", "_t1_ct1_ones");
     }
 
-    // CorrT1METJet JEC·JER-corrected pt — the pt at which the JES source is evaluated.
-    df = df.Define("_t1_ct1_corrpt",
-                   [](const T1JetBlocks& b, const RVec<float>& jer) {
+    // CorrT1METJet JEC-corrected (pre-JER) pt — the baseline at which the JES variation
+    // factor is evaluated (u at the JEC pt, then JER re-evaluated on the shifted pt),
+    // matching the JERC ordering used for the main jets in defineJESVariation.
+    df = df.Define("_t1_ct1_jecpt",
+                   [](const T1JetBlocks& b) {
                        RVec<float> o(b.corrjec.size());
                        for (size_t i = 0; i < b.corrjec.size(); ++i)
-                           o[i] = static_cast<float>(b.rawmusubpt[i] * b.corrjec[i]
-                                                     * (i < jer.size() ? (double)jer[i] : 1.0));
+                           o[i] = static_cast<float>(b.rawmusubpt[i] * b.corrjec[i]);
                        return o;
                    },
-                   {"_t1_ct1_blocks", "_t1_ct1_jer"});
+                   {"_t1_ct1_blocks"});
 
-    // Per-source CorrT1METJet JES shift columns (same 22 Regrouped sources as the main jets).
+    // Per-source CorrT1METJet JES variation factors (same 22 Regrouped sources as the
+    // main jets, same JES-before-JER ordering): v = (1 ± u(eta, pt_JEC)) · c_JER(pt_JEC·(1±u)).
     if (!isData && g_storeSysts) {
+        // Per-jet matched gen pt (ΔR<0.2 to GenJet) for the re-evaluated JER inside the
+        // variation — same matching as build_ct1_jer above.
+        df = df.Define("_t1_ct1_genpt",
+                       [](const RVec<float>& eta, const RVec<float>& phi,
+                          const RVec<float>& gpt, const RVec<float>& geta, const RVec<float>& gphi) {
+                           RVec<float> out(eta.size(), -1.0f);
+                           for (size_t i = 0; i < eta.size(); ++i) {
+                               double best = 0.2 * 0.2;
+                               for (size_t g = 0; g < gpt.size(); ++g) {
+                                   const double dphi = std::atan2(std::sin((double)phi[i] - (double)gphi[g]),
+                                                                  std::cos((double)phi[i] - (double)gphi[g]));
+                                   const double deta = (double)eta[i] - (double)geta[g];
+                                   const double dr2  = deta * deta + dphi * dphi;
+                                   if (dr2 < best) { best = dr2; out[i] = gpt[g]; }
+                               }
+                           }
+                           return out;
+                       },
+                       {"CorrT1METJet_eta", "CorrT1METJet_phi", "GenJet_pt", "GenJet_eta", "GenJet_phi"});
+        df = df.Define("_t1_ct1_seedpt",
+                       [](const T1JetBlocks& b) {
+                           RVec<float> o(b.rawmusubpt.size());
+                           for (size_t i = 0; i < b.rawmusubpt.size(); ++i)
+                               o[i] = static_cast<float>(b.rawmusubpt[i]);
+                           return o;
+                       },
+                       {"_t1_ct1_blocks"});
         for (const auto& src : kJESRegroupedSources) {
             for (const char* dir : kJESDirections) {
                 const float sign = (std::string(dir) == "Up") ? +1.0f : -1.0f;
-                auto eval = makeJESShiftEvaluator(jetEnergyCorrections,
-                                                  jetEnergyCorrections_JEC_prefix,
-                                                  jetEnergyCorrections_JEC_suffix,
-                                                  jetEnergyCorrections_yearToken,
-                                                  src.base_source, src.yearDecorrelated, sign);
-                df = df.Define("_t1_ct1_shift_jes" + std::string(src.label) + dir, eval,
-                               {"year", "_t1_ct1_corrpt", "CorrT1METJet_eta"});
+                auto eval = makeJESVarEvaluator(jetEnergyCorrections(),
+                                                jetEnergyCorrections_JEC_prefix(),
+                                                jetEnergyCorrections_JEC_suffix(),
+                                                jetEnergyCorrections_yearToken(),
+                                                jetEnergyResolution_JER_res_name(),
+                                                jetEnergyResolution_JER_sf_name(),
+                                                jetEnergyResolution_smear(),
+                                                src.base_source, src.yearDecorrelated, sign);
+                df = df.Define("_t1_ct1_var_jes" + std::string(src.label) + dir, eval,
+                               {"year", "_t1_ct1_jecpt", "CorrT1METJet_eta", "_t1_ct1_genpt",
+                                "_t1_ct1_seedpt", "Rho_fixedGridRhoFastjetAll", "event"});
             }
         }
     }
@@ -855,13 +1347,26 @@ RNode applyType1MET(RNode df, bool isData) {
     df = df.Define("met_pt",  "(float)_t1_met_nom.first");
     df = df.Define("met_phi", "(float)_t1_met_nom.second");
 
-    // Per-variation MET: swap in the JES shift for BOTH collections.
+    // Per-variation MET.
     if (!isData) {
+        // JES: swap in the full per-source variation factor (JES shift + re-evaluated
+        // JER, relative to the JEC pt) for BOTH collections; the nominal-JER column is
+        // replaced by ones since the variation factor already carries its own JER.
         for (const auto& sfx : jesVariationSuffixes()) {
             const std::string metCol = "_t1_met_" + sfx;
             df = df.Define(metCol, met_from,
-                           {"_t1_jet_blocks", "_t1_jer", "_Jet_shift_" + sfx,
-                            "_t1_ct1_blocks", "_t1_ct1_jer", "_t1_ct1_shift_" + sfx,
+                           {"_t1_jet_blocks", "_t1_jet_ones", "_Jet_var_" + sfx,
+                            "_t1_ct1_blocks", "_t1_ct1_ones", "_t1_ct1_var_" + sfx,
+                            "RawPuppiMET_pt", "RawPuppiMET_phi"});
+            df = df.Define("met_pt_"  + sfx, "(float)" + metCol + ".first");
+            df = df.Define("met_phi_" + sfx, "(float)" + metCol + ".second");
+        }
+        // JER: swap in the ±1σ smear factor for BOTH collections (JES shift stays 1).
+        for (const auto& sfx : jerVariationSuffixes()) {
+            const std::string metCol = "_t1_met_" + sfx;
+            df = df.Define(metCol, met_from,
+                           {"_t1_jet_blocks", "_t1_jer_" + sfx, "_t1_jet_ones",
+                            "_t1_ct1_blocks", "_t1_ct1_jer_" + sfx, "_t1_ct1_ones",
                             "RawPuppiMET_pt", "RawPuppiMET_phi"});
             df = df.Define("met_pt_"  + sfx, "(float)" + metCol + ".first");
             df = df.Define("met_phi_" + sfx, "(float)" + metCol + ".second");
@@ -872,191 +1377,68 @@ RNode applyType1MET(RNode df, bool isData) {
 
 /*
 ############################################
-JET ENERGY RESOLUTION — hybrid smearing (MC only)
-############################################
-
-Per AK4 jet (using the JEC-corrected pt that this function consumes):
-  res = PtResolution(eta, pt, rho)                        // relative resolution
-  sf  = ScaleFactor(eta, "nom"|"up"|"down")               // data/MC width ratio
-  pt_smear = JERSmear(pt, eta, gen_pt_or_-1, rho, event, res, sf)
-               // hybrid: scaling when |pt - pt_gen| < 3*res*pt and gen-matched (genJetIdx>=0),
-               // stochastic Gaussian otherwise. Always >= 0.
-  pt_new   = pt * pt_smear ; mass_new = mass * pt_smear
-
-Propagates the smearing to met_pt / met_phi via Type-I-style recipe.
-*/
-
-RNode applyJetEnergyResolution(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
-                               const std::unordered_map<std::string, correction::CorrectionSet>& cset_jer_smear,
-                               const std::unordered_map<std::string, std::string>& jer_res_map,
-                               const std::unordered_map<std::string, std::string>& jer_sf_map,
-                               RNode df, std::string variation) {
-
-    const std::string vary = (variation == "nominal") ? "nom" : variation;
-
-    auto compute_smear = [cset_jerc, cset_jer_smear, jer_res_map, jer_sf_map, vary](
-            std::string year,
-            RVec<float> pt, RVec<float> eta,
-            RVec<short> genJet_idx, RVec<float> genJet_pt,
-            float rho, unsigned long long event) {
-
-        RVec<float> factor(pt.size(), 1.0f);
-        if (pt.empty()) return factor;
-
-        auto cs_it = cset_jerc.find(year);
-        auto sm_it = cset_jer_smear.find("jer_smear");
-        auto rn_it = jer_res_map.find(year);
-        auto sn_it = jer_sf_map.find(year);
-        if (cs_it == cset_jerc.end() || sm_it == cset_jer_smear.end()
-            || rn_it == jer_res_map.end() || sn_it == jer_sf_map.end()) {
-            throw std::runtime_error("AK4 JER: resolution / SF / smear inputs not configured for year '"
-                                     + year + "'. Refusing to run with jets un-smeared — add this year to the "
-                                       "JER maps in corrections.h.");
-        }
-
-        std::shared_ptr<const correction::Correction> res, sf, smear;
-        try {
-            res   = cs_it->second.at(rn_it->second);
-            sf    = cs_it->second.at(sn_it->second);
-            smear = sm_it->second.at("JERSmear");
-        } catch (const std::out_of_range&) {
-            throw std::runtime_error("AK4 JER: a res/sf key (res='" + rn_it->second + "', sf='" + sn_it->second
-                                     + "') was not found in the pinned jet_jerc.json.gz for year '" + year
-                                     + "'. The JER tag string in corrections.h is stale relative to the pinned "
-                                       "snapshot (version drift). Refusing to run with jets un-smeared.");
-        }
-
-        for (size_t i = 0; i < pt.size(); ++i) {
-            const float gen_pt = (genJet_idx[i] >= 0 && genJet_idx[i] < (int)genJet_pt.size())
-                                     ? genJet_pt[genJet_idx[i]] : -1.0f;
-            double r  = evalJERCorrection(*res, (double)eta[i], (double)pt[i], (double)rho, vary);
-            double s  = evalJERCorrection(*sf,  (double)eta[i], (double)pt[i], (double)rho, vary);
-            double sm = smear->evaluate({(double)pt[i], (double)eta[i], (double)gen_pt,
-                                         (double)rho, (int)event, r, s});
-            factor[i] = static_cast<float>(sm);
-        }
-        return factor;
-    };
-
-    // NOTE: MET is no longer propagated here. Jet_jerFactor is consumed by applyType1MET(),
-    // which folds JEC*JER into the per-jet correction when rebuilding the Type-I MET from
-    // RawPuppiMET. This function only smears the jets.
-    return df
-        .Define("Jet_jerFactor", compute_smear,
-                {"year", "Jet_pt", "Jet_eta", "Jet_genJetIdx", "GenJet_pt",
-                 "Rho_fixedGridRhoFastjetAll", "event"})
-        .Redefine("Jet_pt",   "Jet_pt   * Jet_jerFactor")
-        .Redefine("Jet_mass", "Jet_mass * Jet_jerFactor");
-}
-
-/*
-############################################
-FAT JET (AK8) ENERGY RESOLUTION — hybrid smearing (MC only)
-############################################
-
-Same recipe as AK4 but reading FatJet_* + GenJetAK8_* and the AK8PFPuppi resolution/SF
-keys. Does NOT propagate to MET.
-*/
-
-RNode applyFatJetEnergyResolution(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
-                                  const std::unordered_map<std::string, correction::CorrectionSet>& cset_jer_smear,
-                                  const std::unordered_map<std::string, std::string>& jer_res_map,
-                                  const std::unordered_map<std::string, std::string>& jer_sf_map,
-                                  RNode df, std::string variation) {
-
-    const std::string vary = (variation == "nominal") ? "nom" : variation;
-
-    auto compute_smear = [cset_jerc, cset_jer_smear, jer_res_map, jer_sf_map, vary](
-            std::string year,
-            RVec<float> pt, RVec<float> eta,
-            RVec<short> genJet_idx, RVec<float> genJet_pt,
-            float rho, unsigned long long event) {
-
-        RVec<float> factor(pt.size(), 1.0f);
-        if (pt.empty()) return factor;
-
-        auto cs_it = cset_jerc.find(year);
-        auto sm_it = cset_jer_smear.find("jer_smear");
-        auto rn_it = jer_res_map.find(year);
-        auto sn_it = jer_sf_map.find(year);
-        if (cs_it == cset_jerc.end() || sm_it == cset_jer_smear.end()
-            || rn_it == jer_res_map.end() || sn_it == jer_sf_map.end()) {
-            throw std::runtime_error("AK8 JER: resolution / SF / smear inputs not configured for year '"
-                                     + year + "'. Refusing to run with fat jets un-smeared — add this year to "
-                                       "the JER maps in corrections.h.");
-        }
-
-        std::shared_ptr<const correction::Correction> res, sf, smear;
-        try {
-            res   = cs_it->second.at(rn_it->second);
-            sf    = cs_it->second.at(sn_it->second);
-            smear = sm_it->second.at("JERSmear");
-        } catch (const std::out_of_range&) {
-            throw std::runtime_error("AK8 JER: a res/sf key (res='" + rn_it->second + "', sf='" + sn_it->second
-                                     + "') was not found in the pinned fatJet_jerc.json.gz for year '" + year
-                                     + "'. The JER tag string in corrections.h is stale relative to the pinned "
-                                       "snapshot (version drift). Refusing to run with fat jets un-smeared.");
-        }
-
-        for (size_t i = 0; i < pt.size(); ++i) {
-            const float gen_pt = (genJet_idx[i] >= 0 && genJet_idx[i] < (int)genJet_pt.size())
-                                     ? genJet_pt[genJet_idx[i]] : -1.0f;
-            double r  = evalJERCorrection(*res, (double)eta[i], (double)pt[i], (double)rho, vary);
-            double s  = evalJERCorrection(*sf,  (double)eta[i], (double)pt[i], (double)rho, vary);
-            double sm = smear->evaluate({(double)pt[i], (double)eta[i], (double)gen_pt,
-                                         (double)rho, (int)event, r, s});
-            factor[i] = static_cast<float>(sm);
-        }
-        return factor;
-    };
-
-    return df
-        .Define("FatJet_jerFactor", compute_smear,
-                {"year", "FatJet_pt", "FatJet_eta", "FatJet_genJetAK8Idx", "GenJetAK8_pt",
-                 "Rho_fixedGridRhoFastjetAll", "event"})
-        .Redefine("FatJet_pt",   "FatJet_pt   * FatJet_jerFactor")
-        .Redefine("FatJet_mass", "FatJet_mass * FatJet_jerFactor");
-}
-
-/*
-############################################
-JET VETO MAPS
+MET PHI CORRECTIONS
 ############################################
 */
 
-RNode applyJetVetoMaps(RNode df) {
-    auto eval_correction = [] (std::string year, RVec<float> pt, RVec<float> eta, RVec<float> phi, RVec<float> jet_id, RVec<float> jet_nuEmEF, RVec<float> jet_chEmEF) {
-        RVec<bool> jet_veto_map;
+RNode applyMETPhiCorrections(RNode df, bool isData) {
+    auto eval_correction = [isData] (std::string year, float pt, float phi, unsigned char npvs, unsigned int run) {
+        double pt_corr = pt;
+        double phi_corr = phi;
         
-        if (jetVetoMaps.find(year) == jetVetoMaps.end()) {
+        if (metCorrections().find(year) == metCorrections().end()) {
             static std::unordered_set<std::string> warned_years;
             if (warned_years.find(year) == warned_years.end()) {
-                std::cout << "Warning: Jet veto map for year " << year << " not found. Setting all jets to not vetoed." << std::endl;
+                std::cout << "Warning: MET correction set for year " << year << " not found. Skipping MET phi corrections." << std::endl;
                 warned_years.insert(year);
             }
-            for (size_t i = 0; i < eta.size(); i++) {
-                jet_veto_map.push_back(false);
-            }
-            return jet_veto_map;
+            return std::make_pair(static_cast<float>(pt_corr), static_cast<float>(phi_corr));
         }
 
-        for (size_t i = 0; i < eta.size(); i++) {
-            float eta_ = eta[i];
-            if (std::abs(eta_) > 5.19) {
-                eta_ = 5.19 * (eta_ > 0 ? 1 : -1);
-            }
-            bool is_vetoed = jetVetoMaps.at(year).at(jetVetoMap_names.at(year))->evaluate({"jetvetomap", eta_, phi[i]}) != 0;
-            if (is_vetoed && (pt[i] > 15.0 && jet_id[i] == 6 && (jet_nuEmEF[i] + jet_chEmEF[i]) < 0.9)) {
-                jet_veto_map.push_back(true);
-            } else {
-                jet_veto_map.push_back(false);
-            }
-        }
+        std::string pt_corr_name = isData ? "pt_metphicorr_puppimet_data" : "pt_metphicorr_puppimet_mc";
+        std::string phi_corr_name = isData ? "phi_metphicorr_puppimet_data" : "phi_metphicorr_puppimet_mc";
 
-        return jet_veto_map;
+        // Note the correction json is only defined for up to 6500, so do not pass larger values
+        float pt_max = 6499.9;
+        float pt_to_pass = std::min(pt,pt_max);
+        pt_corr = metCorrections().at(year).at(pt_corr_name)->evaluate({pt_to_pass, phi, static_cast<double>(npvs), static_cast<double>(run)});
+        phi_corr = metCorrections().at(year).at(phi_corr_name)->evaluate({pt_to_pass, phi, static_cast<double>(npvs), static_cast<double>(run)});
+        
+        return std::make_pair(static_cast<float>(pt_corr), static_cast<float>(phi_corr));
     };
-    
-    return df.Define("Jet_vetoMap", eval_correction, {"year", "Jet_pt", "Jet_eta", "Jet_phi", "Jet_jetId", "Jet_neEmEF", "Jet_chEmEF"});
+    // Runs AFTER applyType1MET, so it refines the already-rebuilt (met_pt, met_phi) rather than
+    // starting from PuppiMET. Run 3 has no met.json configured (see metCorrections in
+    // corrections.cpp) → no-op there;
+    // the φ correction currently only touches the nominal MET, not the JES-varied copies.
+    return df.Define("_MET_phicorr", eval_correction, {"year", "met_pt", "met_phi", "PV_npvs", "run"})
+            .Redefine("met_pt",  "_MET_phicorr.first")
+            .Redefine("met_phi", "_MET_phicorr.second");
+}
+
+/*
+############################################
+HEM Corrections
+############################################
+*/
+
+RNode HEMCorrection(RNode df, bool isData) {
+    auto HEMCorrections = [isData](unsigned int run, unsigned long long event, std::string sample_year, RVec<float> pt, RVec<float> eta, RVec<float> phi, RVec<float> jet_id) {
+        RVec<bool> jet_mask;   
+        if (sample_year == "2018" && ((isData && run >= 319077) || (!isData && event % 100 < 64))) {
+            jet_mask = (jet_id >= 2 && pt > 15.0); // NanoAOD jetID convention https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookNanoAOD#Jets
+                                                    // should still work for current skimmer, which sets jetId==3 : "pass tight ID, fail tightLepVeto", jetId==7 : "pass tight and tightLepVeto ID"
+            auto eta_ = eta[jet_mask];
+            auto phi_ = phi[jet_mask];
+            for (size_t i = 0; i < eta_.size(); i++) {
+                if (eta_[i] > -3.2 && eta_[i] < -1.3 && phi_[i] > -1.57 && phi_[i] < -0.87) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    };
+
+    return df.Define("HEMVeto", HEMCorrections, {"run", "event", "year", "Jet_pt", "Jet_eta", "Jet_phi", "Jet_jetId"}).Filter("HEMVeto");
 }
 
 /*
@@ -1068,7 +1450,7 @@ ELECTRON SCALE AND SMEARING CORRECTIONS
 RNode applyElectronScaleAndSmearing(RNode df, bool isData) {
     auto eval_data_scale = [](std::string year, RVec<float> pt, RVec<float> eta, RVec<float> deltaEtaSC, RVec<float> r9, RVec<unsigned char> seedGain, unsigned int run) {
         RVec<float> scales(pt.size(), 1.0);
-        if (electronSSCorrections.find(year) == electronSSCorrections.end()) {
+        if (electronSSCorrections().find(year) == electronSSCorrections().end()) {
             static std::unordered_set<std::string> warned_years;
             if (warned_years.find(year) == warned_years.end()) {
                 std::cout << "Warning: Electron SS correction set for year " << year << " not found. Skipping scale corrections." << std::endl;
@@ -1079,28 +1461,28 @@ RNode applyElectronScaleAndSmearing(RNode df, bool isData) {
 
         for (size_t i = 0; i < pt.size(); i++) {
             float scEta = eta[i] + deltaEtaSC[i];
-            scales[i] = electronSSCorrections.at(year).compound().at("Scale")->evaluate({"scale", static_cast<double>(run), scEta, r9[i], pt[i], static_cast<double>(seedGain[i])}); 
+            scales[i] = electronSSCorrections().at(year).compound().at("Scale")->evaluate({"scale", static_cast<double>(run), scEta, r9[i], pt[i], static_cast<double>(seedGain[i])}); 
         }
         return scales;
     };
 
     auto eval_data_smearWidth = [](std::string year, RVec<float> pt, RVec<float> eta, RVec<float> deltaEtaSC, RVec<float> r9, RVec<float> scales) {
         RVec<float> widths(pt.size(), 0.0);
-        if (electronSSCorrections.find(year) == electronSSCorrections.end()) {
+        if (electronSSCorrections().find(year) == electronSSCorrections().end()) {
             return widths;
         }
 
         for (size_t i = 0; i < pt.size(); i++) {
             float scEta = eta[i] + deltaEtaSC[i];
             float pt_corr = pt[i] * scales[i];
-            widths[i] = electronSSCorrections.at(year).at("SmearAndSyst")->evaluate({"smear", pt_corr, r9[i], scEta});
+            widths[i] = electronSSCorrections().at(year).at("SmearAndSyst")->evaluate({"smear", pt_corr, r9[i], scEta});
         }
         return widths;
     };
 
     auto eval_mc_smear_factor = [](std::string year, RVec<float> pt, RVec<float> eta, RVec<float> deltaEtaSC, RVec<float> r9, unsigned long long event) {
         RVec<float> smear_factors(pt.size(), 1.0);
-        if (electronSSCorrections.find(year) == electronSSCorrections.end()) {
+        if (electronSSCorrections().find(year) == electronSSCorrections().end()) {
             static std::unordered_set<std::string> warned_years;
             if (warned_years.find(year) == warned_years.end()) {
                 std::cout << "Warning: Electron SS correction set for year " << year << " not found. Skipping smearing corrections." << std::endl;
@@ -1112,7 +1494,7 @@ RNode applyElectronScaleAndSmearing(RNode df, bool isData) {
         TRandom3 rng(event);
         for (size_t i = 0; i < pt.size(); i++) {
             float scEta = eta[i] + deltaEtaSC[i];
-            float smear = electronSSCorrections.at(year).at("SmearAndSyst")->evaluate({"smear", pt[i], r9[i], scEta});
+            float smear = electronSSCorrections().at(year).at("SmearAndSyst")->evaluate({"smear", pt[i], r9[i], scEta});
             smear_factors[i] = 1.0 + smear * rng.Gaus(0.0, 1.0);
         }
         return smear_factors;
@@ -1120,13 +1502,13 @@ RNode applyElectronScaleAndSmearing(RNode df, bool isData) {
 
     auto eval_mc_smearWidth = [](std::string year, RVec<float> pt, RVec<float> eta, RVec<float> deltaEtaSC, RVec<float> r9) {
         RVec<float> widths(pt.size(), 0.0);
-        if (electronSSCorrections.find(year) == electronSSCorrections.end()) {
+        if (electronSSCorrections().find(year) == electronSSCorrections().end()) {
             return widths;
         }
 
         for (size_t i = 0; i < pt.size(); i++) {
             float scEta = eta[i] + deltaEtaSC[i];
-            widths[i] = electronSSCorrections.at(year).at("SmearAndSyst")->evaluate({"smear", pt[i], r9[i], scEta});
+            widths[i] = electronSSCorrections().at(year).at("SmearAndSyst")->evaluate({"smear", pt[i], r9[i], scEta});
         }
         return widths;
     };
@@ -1157,6 +1539,157 @@ RNode applyElectronScaleAndSmearing(RNode df, bool isData) {
 
 /*
 ############################################
+JET VETO MAPS
+############################################
+*/
+
+RNode applyJetVetoMaps(RNode df) {
+    auto eval_correction = [] (std::string year, RVec<float> pt, RVec<float> eta, RVec<float> phi, RVec<float> jet_id, RVec<float> jet_nuEmEF, RVec<float> jet_chEmEF) {
+        RVec<bool> jet_veto_map;
+        
+        if (jetVetoMaps().find(year) == jetVetoMaps().end()) {
+            static std::unordered_set<std::string> warned_years;
+            if (warned_years.find(year) == warned_years.end()) {
+                std::cout << "Warning: Jet veto map for year " << year << " not found. Setting all jets to not vetoed." << std::endl;
+                warned_years.insert(year);
+            }
+            for (size_t i = 0; i < eta.size(); i++) {
+                jet_veto_map.push_back(false);
+            }
+            return jet_veto_map;
+        }
+
+        for (size_t i = 0; i < eta.size(); i++) {
+            float eta_ = eta[i];
+            if (std::abs(eta_) > 5.19) {
+                eta_ = 5.19 * (eta_ > 0 ? 1 : -1);
+            }
+            bool is_vetoed = jetVetoMaps().at(year).at(jetVetoMap_names.at(year))->evaluate({"jetvetomap", eta_, phi[i]}) != 0;
+            if (is_vetoed && (pt[i] > 15.0 && jet_id[i] == 6 && (jet_nuEmEF[i] + jet_chEmEF[i]) < 0.9)) {
+                jet_veto_map.push_back(true);
+            } else {
+                jet_veto_map.push_back(false);
+            }
+        }
+
+        return jet_veto_map;
+    };
+    
+    return df.Define("Jet_vetoMap", eval_correction, {"year", "Jet_pt", "Jet_eta", "Jet_phi", "Jet_jetId", "Jet_neEmEF", "Jet_chEmEF"});
+}
+
+/*
+############################################
+MET UNCLUSTERED CORRECTIONS
+############################################
+*/
+
+RNode applyMETUnclusteredCorrections(RNode df, std::string variation) {
+    if (variation == "up") {
+        return df.Define("_MET_uncert_dx", "met_pt * TMath::Cos(met_phi) + MET_MetUnclustEnUpDeltaX")
+                .Define("_MET_uncert_dy", "met_pt * TMath::Sin(met_phi) + MET_MetUnclustEnUpDeltaY")
+                .Redefine("met_pt", "(float)TMath::Sqrt(_MET_uncert_dx * _MET_uncert_dx + _MET_uncert_dy * _MET_uncert_dy)");
+    }
+
+    else if (variation == "down") {
+        return df.Define("_MET_uncert_dx", "met_pt * TMath::Cos(met_phi) - MET_MetUnclustEnUpDeltaX")
+                .Define("_MET_uncert_dy", "met_pt * TMath::Sin(met_phi) - MET_MetUnclustEnUpDeltaY")
+                .Redefine("met_pt", "(float)TMath::Sqrt(_MET_uncert_dx * _MET_uncert_dx + _MET_uncert_dy * _MET_uncert_dy)");
+    }
+    return df;
+}
+
+/*
+############################################
+JET MASS SCALE (JMS) AND RESOLUTION (JMR) — generic, per-mass-column
+############################################
+
+Column-agnostic helpers: pass the target mass branch (and, for JMR, the gen
+reference mass + gen-index columns) as arguments so the same code serves
+`FatJet_msoftdrop`, the GloParT regressed mass, or any other analysis mass
+variable.
+
+  JMS  : m' = max(0, m + Δshift[year]) // additive shift in GeV
+  JMR  : matched   →  m' = max(0, m_gen + f * (m - m_gen))
+         unmatched →  m' = max(0, m * (1 + √max(f²-1,0) * σrel[year] * N(0,1)))
+
+For msd, the POG-standard proxy is `GenJetAK8_mass[FatJet_genJetAK8Idx]`.
+
+Currently unwired — this analysis calibrates JMS/JMR on the GloParT mass, not
+on msd, and the GloParT calibration hasn't been derived yet. 
+When it lands, wire the calls into `applyMCCorrections` with the
+GloParT column names + per-era shift/factor/σ_rel maps from the calibration
+fit. Up/down systematic variants add a `variation` arg carrying the ±1σ
+shift/scale.
+*/
+
+RNode applyJetMassScale(const std::unordered_map<std::string, float>& shift_map,
+                     const std::string& mass_col,
+                     RNode df) {
+    auto eval = [shift_map, mass_col](std::string year, RVec<float> m) {
+        auto it = shift_map.find(year);
+        if (it == shift_map.end()) {
+            static std::unordered_set<std::string> warned;
+            if (warned.insert(mass_col + "/" + year).second) {
+                std::cout << "Warning: mass-scale shift not defined for year " << year
+                          << " on column " << mass_col << ". Skipping." << std::endl;
+            }
+            return m;
+        }
+        const float shift = it->second;
+        if (shift == 0.0f || m.empty()) return m;
+        for (auto& x : m) x = std::max(0.0f, x + shift);
+        return m;
+    };
+    return df.Redefine(mass_col, eval, {"year", mass_col});
+}
+
+RNode applyJetMassResolution(const std::unordered_map<std::string, float>& factor_map,
+                          const std::unordered_map<std::string, float>& sigma_rel_map,
+                          const std::string& mass_col,
+                          const std::string& gen_mass_col,
+                          const std::string& gen_idx_col,
+                          RNode df) {
+    auto eval = [factor_map, sigma_rel_map, mass_col](std::string year,
+                             RVec<float> m,
+                             RVec<short> gen_idx, RVec<float> gen_mass,
+                             unsigned int lumi, unsigned long long event) {
+        auto it = factor_map.find(year);
+        if (it == factor_map.end()) {
+            static std::unordered_set<std::string> warned;
+            if (warned.insert(mass_col + "/" + year).second) {
+                std::cout << "Warning: mass-resolution factor not defined for year " << year
+                          << " on column " << mass_col << ". Skipping." << std::endl;
+            }
+            return m;
+        }
+        const float f = it->second;
+        if (f == 1.0f || m.empty()) return m;
+
+        const float widen = std::sqrt(std::max(f * f - 1.0f, 0.0f));
+        auto sr_it = sigma_rel_map.find(year);
+        const float sigma_rel = (sr_it != sigma_rel_map.end()) ? sr_it->second : 1.0f;
+        TRandom3 rng((static_cast<unsigned long long>(lumi) << 10) ^ event);
+        for (size_t i = 0; i < m.size(); ++i) {
+            const bool matched = (gen_idx[i] >= 0
+                                  && gen_idx[i] < static_cast<int>(gen_mass.size()));
+            if (matched) {
+                const float m_gen = gen_mass[gen_idx[i]];
+                m[i] = std::max(0.0f, m_gen + f * (m[i] - m_gen));
+            } else {
+                const float kick = static_cast<float>(rng.Gaus(0.0, 1.0));
+                m[i] = std::max(0.0f, m[i] * (1.0f + widen * sigma_rel * kick));
+            }
+        }
+        return m;
+    };
+    return df.Redefine(mass_col, eval,
+                       {"year", mass_col, gen_idx_col, gen_mass_col,
+                        "luminosityBlock", "event"});
+}
+
+/*
+############################################
 GENERAL CORRECTIONS
 ############################################
 */
@@ -1167,13 +1700,13 @@ RNode applyDataCorrections(RNode df_) {
     auto df = df_.Define("_Jet_rawpt", "(1.0f - Jet_rawFactor) * Jet_pt");
     // Re-apply the latest JEC stack (raw recovery + L1*L2*L3*Residual compound). No MET
     // propagation here — Type-I MET is rebuilt from RawPuppiMET in applyType1MET below.
-    df = applyJetEnergyCorrections(jetEnergyCorrections,
-                                   jetEnergyCorrections_JEC_prefix,
-                                   jetEnergyCorrections_JEC_suffix,
+    df = applyJetEnergyCorrections(jetEnergyCorrections(),
+                                   jetEnergyCorrections_JEC_prefix(),
+                                   jetEnergyCorrections_JEC_suffix(),
                                    df, /*isData=*/true);
-    df = applyFatJetEnergyCorrections(fatJetEnergyCorrections,
-                                      fatJetEnergyCorrections_JEC_prefix,
-                                      fatJetEnergyCorrections_JEC_suffix,
+    df = applyFatJetEnergyCorrections(fatJetEnergyCorrections(),
+                                      jetEnergyCorrections_JEC_prefix(),   // same JEC release for AK4 and AK8
+                                      fatJetEnergyCorrections_JEC_suffix(),
                                       df, /*isData=*/true);
     // Rebuild Type-I MET (nominal only for data), then apply the Run 2 MET-φ correction on top.
     df = applyType1MET(df, /*isData=*/true);
@@ -1189,28 +1722,32 @@ RNode applyMCCorrections(RNode df_) {
     // recovered from the mutated columns afterwards).
     auto df = df_.Define("_Jet_rawpt", "(1.0f - Jet_rawFactor) * Jet_pt");
     // Nominal JEC for AK4 and AK8 (no MET propagation here).
-    df = applyJetEnergyCorrections(jetEnergyCorrections,
-                                   jetEnergyCorrections_JEC_prefix,
-                                   jetEnergyCorrections_JEC_suffix,
+    df = applyJetEnergyCorrections(jetEnergyCorrections(),
+                                   jetEnergyCorrections_JEC_prefix(),
+                                   jetEnergyCorrections_JEC_suffix(),
                                    df, /*isData=*/false);
-    df = applyFatJetEnergyCorrections(fatJetEnergyCorrections,
-                                      fatJetEnergyCorrections_JEC_prefix,
-                                      fatJetEnergyCorrections_JEC_suffix,
+    df = applyFatJetEnergyCorrections(fatJetEnergyCorrections(),
+                                      jetEnergyCorrections_JEC_prefix(),   // same JEC release for AK4 and AK8
+                                      fatJetEnergyCorrections_JEC_suffix(),
                                       df, /*isData=*/false);
-    // JER smearing on top of JEC-corrected jets (defines Jet_jerFactor, consumed by applyType1MET).
-    df = applyJetEnergyResolution(jetEnergyCorrections,
-                                  jetEnergyResolution_smear,
-                                  jetEnergyResolution_JER_res_name,
-                                  jetEnergyResolution_JER_sf_name,
-                                  df, /*variation=*/"nominal");
-    df = applyFatJetEnergyResolution(fatJetEnergyCorrections,
-                                     jetEnergyResolution_smear,
-                                     fatJetEnergyResolution_JER_res_name,
-                                     fatJetEnergyResolution_JER_sf_name,
-                                     df, /*variation=*/"nominal");
+    // JER smearing on top of JEC-corrected jets (defines Jet_jerFactor and, with systematics
+    // enabled, the jerUp/jerDn factor + kinematic branches — all consumed by applyType1MET).
+    df = applyJetEnergyResolution(jetEnergyCorrections(),
+                                  jetEnergyResolution_smear(),
+                                  jetEnergyResolution_JER_res_name(),
+                                  jetEnergyResolution_JER_sf_name(),
+                                  jetEnergyResolution_JER_unc_name(),
+                                  df, /*storeVariations=*/g_storeSysts);
+    df = applyFatJetEnergyResolution(fatJetEnergyCorrections(),
+                                     jetEnergyResolution_smear(),
+                                     fatJetEnergyResolution_JER_res_name(),
+                                     fatJetEnergyResolution_JER_sf_name(),
+                                     fatJetEnergyResolution_JER_unc_name(),
+                                     df, /*storeVariations=*/g_storeSysts);
     // JES uncertainties — 11 Regrouped V2 sources × {Up, Dn} as suffixed branches.
-    // Must run after the nominal JEC+JER so the shift sits on top of the corrected baseline
-    // (defines _Jet_shift_<sfx>, consumed by applyType1MET for the per-variation MET).
+    // Must run after the nominal JEC+JER (consumes their pre-smear snapshots; the shift is
+    // applied on the JEC pt with JER re-evaluated on the shifted pt, per the JERC ordering)
+    // (defines _Jet_var_<sfx>, consumed by applyType1MET for the per-variation MET).
     if (g_storeSysts) df = applyJESVariations(df);
     // Rebuild Type-I MET from RawPuppiMET over Jet + CorrT1METJet, for the nominal and every
     // JES variation, then apply the Run 2 MET-φ correction on top of the nominal MET.

--- a/preselection/src/corrections.cpp
+++ b/preselection/src/corrections.cpp
@@ -111,16 +111,12 @@ HEM Corrections
 
 RNode HEMCorrection(RNode df, bool isData) {
     auto HEMCorrections = [isData](unsigned int run, unsigned long long event, std::string sample_year, RVec<float> pt, RVec<float> eta, RVec<float> phi, RVec<float> jet_id) {
-        RVec<bool> jet_mask;
-        if (sample_year.find("2016") != std::string::npos) {
-            jet_mask = (jet_id >= 1 && pt > 15.0);
-        } else {
-            jet_mask = (jet_id >= 2 && pt > 15.0);
-        }
-        // Need to check if there is dependence on jet ID in v15
-        auto eta_ = eta[jet_mask];
-        auto phi_ = phi[jet_mask];
+        RVec<bool> jet_mask;   
         if (sample_year == "2018" && ((isData && run >= 319077) || (!isData && event % 100 < 64))) {
+            jet_mask = (jet_id >= 2 && pt > 15.0); // NanoAOD jetID convention https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookNanoAOD#Jets
+                                                    // should still work for current skimmer, which sets jetId==3 : "pass tight ID, fail tightLepVeto", jetId==7 : "pass tight and tightLepVeto ID"
+            auto eta_ = eta[jet_mask];
+            auto phi_ = phi[jet_mask];
             for (size_t i = 0; i < eta_.size(); i++) {
                 if (eta_[i] > -3.2 && eta_[i] < -1.3 && phi_[i] > -1.57 && phi_[i] < -0.87) {
                     return false;

--- a/preselection/src/corrections.h
+++ b/preselection/src/corrections.h
@@ -28,6 +28,7 @@ RVec<bool> isbTagMedium(std::string year, RVec<float> btag_score);
 RVec<bool> isbTagTight(std::string year, RVec<float> btag_score);
 
 
+// Note: Re-using 2024 WPs for 2022-2023
 const std::unordered_map <std::string, correction::CorrectionSet> btaggingCorrections = {
     {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run2-2016preVFP-UL-NanoAODv15/latest/btagging.json.gz")},
     {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run2-2016postVFP-UL-NanoAODv15/latest/btagging.json.gz")},
@@ -87,6 +88,7 @@ static std::unordered_map<std::string, float> btaggingWPMap_Tight = {
 MET CORRECTIONS
 ############################################
 */
+// FIXME: met corrections missing for v15
 const std::unordered_map<std::string, correction::CorrectionSet> metCorrections = {
     {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016preVFP-UL-NanoAODv9/latest/met.json.gz")},
     {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016postVFP-UL-NanoAODv9/latest/met.json.gz")},
@@ -102,17 +104,50 @@ RNode applyMETUnclusteredCorrections(RNode df, std::string variation);
 
 /*
 ############################################
-JET MASS SCALE AND RESOLUTION CORRECTIONS
+JET MASS SCALE (JMS) AND RESOLUTION (JMR)
 ############################################
+
+Convention:
+  - JMS  : *additive* shift on FatJet_msoftdrop, in GeV. ±1σ variation = jmsr_scale.
+           Central = 0.0 GeV (no shift).
+  - JMR  : *multiplicative* width factor wrt the gen mass. ±1σ variation =
+           jmsr_smear. Central = 1.0 (no widening).
+
+We currently store only central values (= identity) since no calibration has been
+derived yet. Replace these with per-era values from the calibration fit when
+available; the up/down systematic variants can then be added by passing
+variation = "up"/"down" with the derived ±1σ shift/scale.
 */
-const std::unordered_map<std::string, correction::CorrectionSet> jetMassCorrections = {
-    {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016preVFP-UL-NanoAODv9/latest/jmar.json.gz")},
-    {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016postVFP-UL-NanoAODv9/latest/jmar.json.gz")},
-    {"2017", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2017-UL-NanoAODv9/latest/jmar.json.gz")},
-    {"2018", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2018-UL-NanoAODv9/latest/jmar.json.gz")}
+
+const std::unordered_map<std::string, float> jetMassScale_central = {
+    {"2016preVFP", 0.0f}, {"2016postVFP", 0.0f}, {"2017", 0.0f}, {"2018", 0.0f},
+    {"2022Re-recoBCD", 0.0f}, {"2022Re-recoE+PromptFG", 0.0f},
+    {"2023PromptC", 0.0f}, {"2023PromptD", 0.0f},
+    {"2024Prompt", 0.0f}
 };
-RNode applyJMSCorrections(std::unordered_map<std::string, correction::CorrectionSet> cset_jms, RNode df, std::string variation);
-RNode applyJMRCorrections(std::unordered_map<std::string, correction::CorrectionSet> cset_jmr, RNode df, std::string variation);
+
+const std::unordered_map<std::string, float> jetMassResolution_central = {
+    {"2016preVFP", 1.0f}, {"2016postVFP", 1.0f}, {"2017", 1.0f}, {"2018", 1.0f},
+    {"2022Re-recoBCD", 1.0f}, {"2022Re-recoE+PromptFG", 1.0f},
+    {"2023PromptC", 1.0f}, {"2023PromptD", 1.0f},
+    {"2024Prompt", 1.0f}
+};
+
+// Relative msoftdrop resolution sigma(msd)/msd. Used by the unmatched stochastic branch
+// of applyJetMassResolution. Placeholder 1.0 — replace with the per-era value from the same
+// calibration fit that derives jetMassResolution_central. With factor f = 1.0 (placeholder)
+// the branch is unreachable, so this value has no effect until both maps are updated together.
+const std::unordered_map<std::string, float> jetMassResolution_sigmaRel_central = {
+    {"2016preVFP", 1.0f}, {"2016postVFP", 1.0f}, {"2017", 1.0f}, {"2018", 1.0f},
+    {"2022Re-recoBCD", 1.0f}, {"2022Re-recoE+PromptFG", 1.0f},
+    {"2023PromptC", 1.0f}, {"2023PromptD", 1.0f},
+    {"2024Prompt", 1.0f}
+};
+
+RNode applyJetMassScale(const std::unordered_map<std::string, float>& jms_shift, RNode df);
+RNode applyJetMassResolution(const std::unordered_map<std::string, float>& jmr_factor,
+                             const std::unordered_map<std::string, float>& jmr_sigma_rel,
+                             RNode df);
 
 /*
 ############################################
@@ -120,10 +155,10 @@ JET ENERGY CORRECTIONS
 ############################################
 */
 const std::unordered_map<std::string, correction::CorrectionSet> jetEnergyCorrections = {
-    {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016preVFP-UL-NanoAODv9/latest/jet_jerc.json.gz")},
-    {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016postVFP-UL-NanoAODv9/latest/jet_jerc.json.gz")},
-    {"2017", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2017-UL-NanoAODv9/latest/jet_jerc.json.gz")},
-    {"2018", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2018-UL-NanoAODv9/latest/jet_jerc.json.gz")},
+    {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016preVFP-UL-NanoAODv15/latest/jet_jerc.json.gz")},
+    {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016postVFP-UL-NanoAODv15/latest/jet_jerc.json.gz")},
+    {"2017", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2017-UL-NanoAODv15/latest/jet_jerc.json.gz")},
+    {"2018", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2018-UL-NanoAODv15/latest/jet_jerc.json.gz")},
     {"2022Re-recoBCD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/latest/jet_jerc.json.gz")},
     {"2022Re-recoE+PromptFG", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22EFGSep23-Summer22EE-NanoAODv12/latest/jet_jerc.json.gz")},
     {"2023PromptC", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23CSep23-Summer23-NanoAODv12/latest/jet_jerc.json.gz")},
@@ -131,27 +166,42 @@ const std::unordered_map<std::string, correction::CorrectionSet> jetEnergyCorrec
     {"2024Prompt", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/latest/jet_jerc.json.gz")}
 };
 
+// AK8 fat-jet JEC/JER lives in fatJet_jerc.json.gz under the same era directories.
+const std::unordered_map<std::string, correction::CorrectionSet> fatJetEnergyCorrections = {
+    {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016preVFP-UL-NanoAODv15/latest/fatJet_jerc.json.gz")},
+    {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016postVFP-UL-NanoAODv15/latest/fatJet_jerc.json.gz")},
+    {"2017", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2017-UL-NanoAODv15/latest/fatJet_jerc.json.gz")},
+    {"2018", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2018-UL-NanoAODv15/latest/fatJet_jerc.json.gz")},
+    {"2022Re-recoBCD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/latest/fatJet_jerc.json.gz")},
+    {"2022Re-recoE+PromptFG", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22EFGSep23-Summer22EE-NanoAODv12/latest/fatJet_jerc.json.gz")},
+    {"2023PromptC", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23CSep23-Summer23-NanoAODv12/latest/fatJet_jerc.json.gz")},
+    {"2023PromptD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23DSep23-Summer23BPix-NanoAODv12/latest/fatJet_jerc.json.gz")},
+    {"2024Prompt", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/latest/fatJet_jerc.json.gz")}
+};
+
 const std::unordered_map<std::string, correction::CorrectionSet> jetEnergyResolution_smear = {
     {"jer_smear", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/JER-Smearing/latest/jer_smear.json.gz")}
 };
 
+// JEC tag base — `<TAG>_MC` and `<TAG>_DATA` compounds (`_L1L2L3Res_<algo>`) live in jet_jerc.json.gz.
+// The trailing `_MC` here is stripped and replaced with `_DATA` at runtime when running on data.
 const std::unordered_map<std::string, std::string> jetEnergyCorrections_JEC_prefix = {
-    {"2016preVFP", "Summer19UL16APV_V7_MC"},
-    {"2016postVFP", "Summer19UL16_V7_MC"},
-    {"2017", "Summer19UL17_V5_MC"},
-    {"2018", "Summer19UL18_V5_MC"},
-    {"2022Re-recoBCD", "Summer22_22Sep2023_V2_MC"},
-    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_V2_MC"},
-    {"2023PromptC", "Summer23Prompt23_V1_MC"},
-    {"2023PromptD", "Summer23BPixPrompt23_V1_MC"},
-    {"2024Prompt", "Summer24Prompt24_V1_MC"}
+    {"2016preVFP", "Summer20UL16APVNanoV15_V1_MC"},
+    {"2016postVFP", "Summer20UL16NanoV15_V1_MC"},
+    {"2017", "Summer20UL17NanoV15_V1_MC"},
+    {"2018", "Summer20UL18NanoV15_V1_MC"},
+    {"2022Re-recoBCD", "Summer22_22Sep2023_V3_MC"},
+    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_V3_MC"},
+    {"2023PromptC", "Summer23Prompt23_V3_MC"},
+    {"2023PromptD", "Summer23BPixPrompt23_V3_MC"},
+    {"2024Prompt", "Summer24Prompt24_V2_MC"}
 };
 
 const std::unordered_map<std::string, std::string> jetEnergyCorrections_JEC_suffix = {
-    {"2016preVFP", "AK4PFchs"},
-    {"2016postVFP", "AK4PFchs"},
-    {"2017", "AK4PFchs"},
-    {"2018", "AK4PFchs"},
+    {"2016preVFP", "AK4PFPuppi"},
+    {"2016postVFP", "AK4PFPuppi"},
+    {"2017", "AK4PFPuppi"},
+    {"2018", "AK4PFPuppi"},
     {"2022Re-recoBCD", "AK4PFPuppi"},
     {"2022Re-recoE+PromptFG", "AK4PFPuppi"},
     {"2023PromptC", "AK4PFPuppi"},
@@ -159,38 +209,123 @@ const std::unordered_map<std::string, std::string> jetEnergyCorrections_JEC_suff
     {"2024Prompt", "AK4PFPuppi"}
 };
 
+// AK8 fat-jet variants — same year keys, AK8PFPuppi algo across all eras.
+const std::unordered_map<std::string, std::string> fatJetEnergyCorrections_JEC_prefix = {
+    {"2016preVFP", "Summer20UL16APVNanoV15_V1_MC"},
+    {"2016postVFP", "Summer20UL16NanoV15_V1_MC"},
+    {"2017", "Summer20UL17NanoV15_V1_MC"},
+    {"2018", "Summer20UL18NanoV15_V1_MC"},
+    {"2022Re-recoBCD", "Summer22_22Sep2023_V3_MC"},
+    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_V3_MC"},
+    {"2023PromptC", "Summer23Prompt23_V3_MC"},
+    {"2023PromptD", "Summer23BPixPrompt23_V3_MC"},
+    {"2024Prompt", "Summer24Prompt24_V2_MC"}
+};
+
+const std::unordered_map<std::string, std::string> fatJetEnergyCorrections_JEC_suffix = {
+    {"2016preVFP", "AK8PFPuppi"},
+    {"2016postVFP", "AK8PFPuppi"},
+    {"2017", "AK8PFPuppi"},
+    {"2018", "AK8PFPuppi"},
+    {"2022Re-recoBCD", "AK8PFPuppi"},
+    {"2022Re-recoE+PromptFG", "AK8PFPuppi"},
+    {"2023PromptC", "AK8PFPuppi"},
+    {"2023PromptD", "AK8PFPuppi"},
+    {"2024Prompt", "AK8PFPuppi"}
+};
+
+// JER tag names 
+// FIXME: 2024 re-uses the 2023BPix JR until a dedicated 2024 release lands
 const std::unordered_map<std::string, std::string> jetEnergyResolution_JER_res_name = {
-    {"2016preVFP", "Summer20UL16APV_JRV3_MC_PtResolution_AK4PFchs"},
-    {"2016postVFP", "Summer20UL16_JRV3_MC_PtResolution_AK4PFchs"},
-    {"2017", "Summer19UL17_JRV2_MC_PtResolution_AK4PFchs"},
-    {"2018", "Summer19UL18_JRV2_MC_PtResolution_AK4PFchs"},
+    {"2016preVFP", "Summer20UL16APV_JRV3_MC_PtResolution_AK4PFPuppi"},
+    {"2016postVFP", "Summer20UL16_JRV3_MC_PtResolution_AK4PFPuppi"},
+    {"2017", "Summer19UL17_JRV3_MC_PtResolution_AK4PFPuppi"},
+    {"2018", "Summer19UL18_JRV2_MC_PtResolution_AK4PFPuppi"},
     {"2022Re-recoBCD", "Summer22_22Sep2023_JRV1_MC_PtResolution_AK4PFPuppi"},
     {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_JRV1_MC_PtResolution_AK4PFPuppi"},
-    {"2023PromptC", "Summer23Prompt23_JRV1_MC_PtResolution_AK4PFPuppi"},
-    {"2023PromptD", "Summer23BPixPrompt23_JRV1_MC_PtResolution_AK4PFPuppi"},
-    {"2024Prompt", "Summer24Prompt24_JRV1_MC_PtResolution_AK4PFPuppi"}
+    {"2023PromptC", "Summer23Prompt23_RunCv1234_JRV1_MC_PtResolution_AK4PFPuppi"},
+    {"2023PromptD", "Summer23BPixPrompt23_RunD_JRV1_MC_PtResolution_AK4PFPuppi"},
+    {"2024Prompt", "Summer23BPixPrompt23_RunD_JRV1_MC_PtResolution_AK4PFPuppi"}
 };
 
 const std::unordered_map<std::string, std::string> jetEnergyResolution_JER_sf_name = {
-    {"2016preVFP", "Summer20UL16APV_JRV3_MC_ScaleFactor_AK4PFchs"},
-    {"2016postVFP", "Summer20UL16_JRV3_MC_ScaleFactor_AK4PFchs"},
-    {"2017", "Summer19UL17_JRV2_MC_ScaleFactor_AK4PFchs"},
-    {"2018", "Summer19UL18_JRV2_MC_ScaleFactor_AK4PFchs"},
+    {"2016preVFP", "Summer20UL16APV_JRV3_MC_ScaleFactor_AK4PFPuppi"},
+    {"2016postVFP", "Summer20UL16_JRV3_MC_ScaleFactor_AK4PFPuppi"},
+    {"2017", "Summer19UL17_JRV3_MC_ScaleFactor_AK4PFPuppi"},
+    {"2018", "Summer19UL18_JRV2_MC_ScaleFactor_AK4PFPuppi"},
     {"2022Re-recoBCD", "Summer22_22Sep2023_JRV1_MC_ScaleFactor_AK4PFPuppi"},
     {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_JRV1_MC_ScaleFactor_AK4PFPuppi"},
-    {"2023PromptC", "Summer23Prompt23_JRV1_MC_ScaleFactor_AK4PFPuppi"},
-    {"2023PromptD", "Summer23BPixPrompt23_JRV1_MC_ScaleFactor_AK4PFPuppi"},
-    {"2024Prompt", "Summer24Prompt24_JRV1_MC_ScaleFactor_AK4PFPuppi"}
+    {"2023PromptC", "Summer23Prompt23_RunCv1234_JRV1_MC_ScaleFactor_AK4PFPuppi"},
+    {"2023PromptD", "Summer23BPixPrompt23_RunD_JRV1_MC_ScaleFactor_AK4PFPuppi"},
+    {"2024Prompt", "Summer23BPixPrompt23_RunD_JRV1_MC_ScaleFactor_AK4PFPuppi"}
 };
 
-RNode applyJetEnergyCorrections(std::unordered_map<std::string, correction::CorrectionSet> cset_jerc, std::unordered_map<std::string, std::string> jec_prefix_map, std::unordered_map<std::string, std::string> jec_suffix_map, RNode df, std::string JEC_type, std::string variation);
-RNode applyJetEnergyResolution(std::unordered_map<std::string, correction::CorrectionSet> cset_jerc, std::unordered_map<std::string, correction::CorrectionSet> cset_jer_smear, std::unordered_map<std::string, std::string> jer_res_map, std::unordered_map<std::string, std::string> jer_sf_map, RNode df, std::string variation);
+// AK8 JER tags — same JR releases as AK4 but with AK8PFPuppi algo.
+const std::unordered_map<std::string, std::string> fatJetEnergyResolution_JER_res_name = {
+    {"2016preVFP", "Summer20UL16APV_JRV3_MC_PtResolution_AK8PFPuppi"},
+    {"2016postVFP", "Summer20UL16_JRV3_MC_PtResolution_AK8PFPuppi"},
+    {"2017", "Summer19UL17_JRV3_MC_PtResolution_AK8PFPuppi"},
+    {"2018", "Summer19UL18_JRV2_MC_PtResolution_AK8PFPuppi"},
+    {"2022Re-recoBCD", "Summer22_22Sep2023_JRV1_MC_PtResolution_AK8PFPuppi"},
+    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_JRV1_MC_PtResolution_AK8PFPuppi"},
+    {"2023PromptC", "Summer23Prompt23_RunCv1234_JRV1_MC_PtResolution_AK8PFPuppi"},
+    {"2023PromptD", "Summer23BPixPrompt23_RunD_JRV1_MC_PtResolution_AK8PFPuppi"},
+    {"2024Prompt", "Summer23BPixPrompt23_RunD_JRV1_MC_PtResolution_AK8PFPuppi"}
+};
+
+const std::unordered_map<std::string, std::string> fatJetEnergyResolution_JER_sf_name = {
+    {"2016preVFP", "Summer20UL16APV_JRV3_MC_ScaleFactor_AK8PFPuppi"},
+    {"2016postVFP", "Summer20UL16_JRV3_MC_ScaleFactor_AK8PFPuppi"},
+    {"2017", "Summer19UL17_JRV3_MC_ScaleFactor_AK8PFPuppi"},
+    {"2018", "Summer19UL18_JRV2_MC_ScaleFactor_AK8PFPuppi"},
+    {"2022Re-recoBCD", "Summer22_22Sep2023_JRV1_MC_ScaleFactor_AK8PFPuppi"},
+    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_JRV1_MC_ScaleFactor_AK8PFPuppi"},
+    {"2023PromptC", "Summer23Prompt23_RunCv1234_JRV1_MC_ScaleFactor_AK8PFPuppi"},
+    {"2023PromptD", "Summer23BPixPrompt23_RunD_JRV1_MC_ScaleFactor_AK8PFPuppi"},
+    {"2024Prompt", "Summer23BPixPrompt23_RunD_JRV1_MC_ScaleFactor_AK8PFPuppi"}
+};
+
+// Nominal JEC: removes the JEC stored in NanoAOD (via Jet_rawFactor) and re-applies the
+// latest L1FastJet * L2Relative * L3Absolute (* L2L3Residual for data) compound from
+// jet_jerc.json.gz. Propagates the change to met_pt / met_phi (Type-I).
+RNode applyJetEnergyCorrections(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
+                                const std::unordered_map<std::string, std::string>& jec_prefix_map,
+                                const std::unordered_map<std::string, std::string>& jec_suffix_map,
+                                RNode df, bool isData);
+
+// JES uncertainty (nominal/up/down). Must run after applyJetEnergyCorrections so the
+// per-source uncertainty is applied on top of the corrected baseline.
+RNode applyJetEnergyScaleVariation(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
+                                   const std::unordered_map<std::string, std::string>& jec_prefix_map,
+                                   const std::unordered_map<std::string, std::string>& jec_suffix_map,
+                                   RNode df, std::string JEC_source, std::string variation);
+
+// JER smearing (MC only). Propagates to met_pt / met_phi as well.
+RNode applyJetEnergyResolution(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
+                               const std::unordered_map<std::string, correction::CorrectionSet>& cset_jer_smear,
+                               const std::unordered_map<std::string, std::string>& jer_res_map,
+                               const std::unordered_map<std::string, std::string>& jer_sf_map,
+                               RNode df, std::string variation);
+
+// AK8 (FatJet_*) variants — same recipe as AK4 but reading FatJet_* / GenJetAK8_* branches
+// and the AK8PFPuppi compound from fatJet_jerc.json.gz. 
+RNode applyFatJetEnergyCorrections(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
+                                   const std::unordered_map<std::string, std::string>& jec_prefix_map,
+                                   const std::unordered_map<std::string, std::string>& jec_suffix_map,
+                                   RNode df, bool isData);
+
+RNode applyFatJetEnergyResolution(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
+                                  const std::unordered_map<std::string, correction::CorrectionSet>& cset_jer_smear,
+                                  const std::unordered_map<std::string, std::string>& jer_res_map,
+                                  const std::unordered_map<std::string, std::string>& jer_sf_map,
+                                  RNode df, std::string variation);
 
 /*
 ############################################
 JET VETO MAPS
 ############################################
 */
+// Run 2 recommendations: https://cms-jerc.web.cern.ch/Recommendations/#run-2_1
 const std::unordered_map<std::string, correction::CorrectionSet> jetVetoMaps = {
     {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016preVFP-UL-NanoAODv9/latest/jetvetomaps.json.gz")},
     {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016postVFP-UL-NanoAODv9/latest/jetvetomaps.json.gz")},

--- a/preselection/src/corrections.h
+++ b/preselection/src/corrections.h
@@ -338,9 +338,13 @@ RNode defineFatJetJESVariation(const std::unordered_map<std::string, correction:
 // Driver: emits all 11 Regrouped V2 sources × {Up, Dn} = 22 variations on AK4 + AK8.
 RNode applyJESVariations(RNode df);
 
+// When called with false before any analysis, disables all JES/JER variation branches
+// (jesVariationSuffixes() returns empty, applyJESVariations becomes a no-op). Use
+// --no_systs to activate nominal-only mode.
+void setStoreSysts(bool v);
+
 // Public accessor for the 22 variation suffixes (e.g. "jesAbsoluteUp",
-// "jesRelativeSampleYearDn"). Single source of truth shared with selections.cpp,
-// which uses it to emit per-variation good-jet masks (Jet_isGood_<sfx>).
+// "jesRelativeSampleYearDn"). Returns empty when setStoreSysts(false) has been called.
 std::vector<std::string> jesVariationSuffixes();
 
 // JER smearing (MC only). Propagates to met_pt / met_phi as well.

--- a/preselection/src/corrections.h
+++ b/preselection/src/corrections.h
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <vector>
 #include <array>
+#include <stdexcept>
 
 #include "ROOT/RDataFrame.hxx"
 #include "ROOT/RDFHelpers.hxx"
@@ -106,19 +107,22 @@ RNode applyMETUnclusteredCorrections(RNode df, std::string variation);
 
 /*
 ############################################
-JET MASS SCALE (JMS) AND RESOLUTION (JMR)
+JET MASS SCALE (JMS) AND RESOLUTION (JMR) — generic, per-mass-column
 ############################################
 
 Convention:
-  - JMS  : *additive* shift on FatJet_msoftdrop, in GeV. ±1σ variation = jmsr_scale.
-           Central = 0.0 GeV (no shift).
-  - JMR  : *multiplicative* width factor wrt the gen mass. ±1σ variation =
-           jmsr_smear. Central = 1.0 (no widening).
+  - JMS  : *additive* shift on the target mass column, in GeV. Central = 0.0 GeV.
+  - JMR  : *multiplicative* width factor wrt the gen reference mass. Central = 1.0.
 
-We currently store only central values (= identity) since no calibration has been
-derived yet. Replace these with per-era values from the calibration fit when
-available; the up/down systematic variants can then be added by passing
-variation = "up"/"down" with the derived ±1σ shift/scale.
+applyJetMassScale / applyJetMassResolution (corrections.cpp) are column-agnostic — the
+mass branch and (for JMR) the gen mass + gen-index branches are passed in. This
+analysis intends to calibrate on the GloParT regressed mass, not FatJet_msoftdrop
+(see CORRECTIONS.md § 5-6), and the calibration is not yet derived — the helpers
+are currently unwired in applyMCCorrections.
+
+The maps below are identity-valued placeholders kept as a template; the GloParT
+calibration will supply its own per-era shift / factor / σ_rel maps. Up/down
+systematic variants come from passing ±1σ shift/scale.
 */
 
 const std::unordered_map<std::string, float> jetMassScale_central = {
@@ -135,8 +139,8 @@ const std::unordered_map<std::string, float> jetMassResolution_central = {
     {"2024Prompt", 1.0f}
 };
 
-// Relative msoftdrop resolution sigma(msd)/msd. Used by the unmatched stochastic branch
-// of applyJetMassResolution. Placeholder 1.0 — replace with the per-era value from the same
+// Relative mass resolution sigma(m)/m used by the unmatched stochastic branch of
+// applyJetMassResolution. Placeholder 1.0 — replace with the per-era value from the same
 // calibration fit that derives jetMassResolution_central. With factor f = 1.0 (placeholder)
 // the branch is unreachable, so this value has no effect until both maps are updated together.
 const std::unordered_map<std::string, float> jetMassResolution_sigmaRel_central = {
@@ -146,43 +150,69 @@ const std::unordered_map<std::string, float> jetMassResolution_sigmaRel_central 
     {"2024Prompt", 1.0f}
 };
 
-RNode applyJetMassScale(const std::unordered_map<std::string, float>& jms_shift, RNode df);
-RNode applyJetMassResolution(const std::unordered_map<std::string, float>& jmr_factor,
-                             const std::unordered_map<std::string, float>& jmr_sigma_rel,
-                             RNode df);
+RNode applyJetMassScale(const std::unordered_map<std::string, float>& shift_map,
+                     const std::string& mass_col, RNode df);
+RNode applyJetMassResolution(const std::unordered_map<std::string, float>& factor_map,
+                          const std::unordered_map<std::string, float>& sigma_rel_map,
+                          const std::string& mass_col,
+                          const std::string& gen_mass_col,
+                          const std::string& gen_idx_col,
+                          RNode df);
 
 /*
 ############################################
 JET ENERGY CORRECTIONS
 ############################################
+
+Run 2 + the 2022/2023 Run 3 eras are pinned to the 2026-06-05 JME snapshot (jet_jerc /
+fatJet_jerc); the 2024Prompt and 2025 eras are pinned to the newer 2026-07-14 snapshot
+(JEC V4/V2, JER JRV2 — see below). JER-Smearing is pinned to 2025-11-03 — NOT the mutable
+`latest/` symlink. The tag strings below are the compound/correction keys that exist inside
+those pinned files. The "2024Prompt" era uses the Summer24Prompt24 tag (JEC V4 / JER JRV2),
+and the "2025" era (2025 data + Summer24 MC) uses the JME-recommended Summer24Prompt25 tag
+(JEC V2 / JER JRV2), both pinned to the 2026-07-14 snapshot. The 2026-07-14 update moved the
+L2L3Residual corrections to signed-η (from |η|) and refreshed the JER SFs; evalJECCompound
+already passes signed eta and resolves inputs by name, so no code change was needed.
+correctionlib has no "give me the newest version" API: the code asks
+for a tag by name, so the file version and the requested tag string must be bumped
+together, deliberately, in one commit. Loading from `latest/` while pinning the tag
+string is what previously let the two drift apart (V3 code vs V4 file -> silent no-op;
+now a hard error, see applyJetEnergyCorrections in corrections.cpp). To adopt a newer
+JME release: pick the new dated dir, find the new recommended tag, and update both
+the paths and the tag maps here.
+
+JES
 */
 const std::unordered_map<std::string, correction::CorrectionSet> jetEnergyCorrections = {
-    {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016preVFP-UL-NanoAODv15/latest/jet_jerc.json.gz")},
-    {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016postVFP-UL-NanoAODv15/latest/jet_jerc.json.gz")},
-    {"2017", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2017-UL-NanoAODv15/latest/jet_jerc.json.gz")},
-    {"2018", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2018-UL-NanoAODv15/latest/jet_jerc.json.gz")},
-    {"2022Re-recoBCD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/latest/jet_jerc.json.gz")},
-    {"2022Re-recoE+PromptFG", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22EFGSep23-Summer22EE-NanoAODv12/latest/jet_jerc.json.gz")},
-    {"2023PromptC", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23CSep23-Summer23-NanoAODv12/latest/jet_jerc.json.gz")},
-    {"2023PromptD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23DSep23-Summer23BPix-NanoAODv12/latest/jet_jerc.json.gz")},
-    {"2024Prompt", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/latest/jet_jerc.json.gz")}
+    {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016preVFP-UL-NanoAODv15/2026-06-05/jet_jerc.json.gz")},
+    {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016postVFP-UL-NanoAODv15/2026-06-05/jet_jerc.json.gz")},
+    {"2017", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2017-UL-NanoAODv15/2026-06-05/jet_jerc.json.gz")},
+    {"2018", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2018-UL-NanoAODv15/2026-06-05/jet_jerc.json.gz")},
+    {"2022Re-recoBCD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/2026-06-05/jet_jerc.json.gz")},
+    {"2022Re-recoE+PromptFG", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22EFGSep23-Summer22EE-NanoAODv12/2026-06-05/jet_jerc.json.gz")},
+    {"2023PromptC", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23CSep23-Summer23-NanoAODv12/2026-06-05/jet_jerc.json.gz")},
+    {"2023PromptD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23DSep23-Summer23BPix-NanoAODv12/2026-06-05/jet_jerc.json.gz")},
+    {"2024Prompt", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2026-07-14/jet_jerc.json.gz")},
+    // 2025 data + Summer24 MC — JME-recommended Summer24Prompt25 (JEC + JER + JES self-contained); pinned to 2026-07-03.
+    {"2025", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-25Prompt-Summer24-NanoAODv15/2026-07-14/jet_jerc.json.gz")}
 };
 
 // AK8 fat-jet JEC/JER lives in fatJet_jerc.json.gz under the same era directories.
 const std::unordered_map<std::string, correction::CorrectionSet> fatJetEnergyCorrections = {
-    {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016preVFP-UL-NanoAODv15/latest/fatJet_jerc.json.gz")},
-    {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016postVFP-UL-NanoAODv15/latest/fatJet_jerc.json.gz")},
-    {"2017", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2017-UL-NanoAODv15/latest/fatJet_jerc.json.gz")},
-    {"2018", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2018-UL-NanoAODv15/latest/fatJet_jerc.json.gz")},
-    {"2022Re-recoBCD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/latest/fatJet_jerc.json.gz")},
-    {"2022Re-recoE+PromptFG", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22EFGSep23-Summer22EE-NanoAODv12/latest/fatJet_jerc.json.gz")},
-    {"2023PromptC", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23CSep23-Summer23-NanoAODv12/latest/fatJet_jerc.json.gz")},
-    {"2023PromptD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23DSep23-Summer23BPix-NanoAODv12/latest/fatJet_jerc.json.gz")},
-    {"2024Prompt", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/latest/fatJet_jerc.json.gz")}
+    {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016preVFP-UL-NanoAODv15/2026-06-05/fatJet_jerc.json.gz")},
+    {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016postVFP-UL-NanoAODv15/2026-06-05/fatJet_jerc.json.gz")},
+    {"2017", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2017-UL-NanoAODv15/2026-06-05/fatJet_jerc.json.gz")},
+    {"2018", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2018-UL-NanoAODv15/2026-06-05/fatJet_jerc.json.gz")},
+    {"2022Re-recoBCD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/2026-06-05/fatJet_jerc.json.gz")},
+    {"2022Re-recoE+PromptFG", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22EFGSep23-Summer22EE-NanoAODv12/2026-06-05/fatJet_jerc.json.gz")},
+    {"2023PromptC", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23CSep23-Summer23-NanoAODv12/2026-06-05/fatJet_jerc.json.gz")},
+    {"2023PromptD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23DSep23-Summer23BPix-NanoAODv12/2026-06-05/fatJet_jerc.json.gz")},
+    {"2024Prompt", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2026-07-14/fatJet_jerc.json.gz")},
+    {"2025", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-25Prompt-Summer24-NanoAODv15/2026-07-14/fatJet_jerc.json.gz")}
 };
 
 const std::unordered_map<std::string, correction::CorrectionSet> jetEnergyResolution_smear = {
-    {"jer_smear", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/JER-Smearing/latest/jer_smear.json.gz")}
+    {"jer_smear", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/JER-Smearing/2025-11-03/jer_smear.json.gz")}
 };
 
 // JEC tag base — `<TAG>_MC` and `<TAG>_DATA` compounds (`_L1L2L3Res_<algo>`) live in jet_jerc.json.gz.
@@ -192,11 +222,12 @@ const std::unordered_map<std::string, std::string> jetEnergyCorrections_JEC_pref
     {"2016postVFP", "Summer20UL16NanoV15_V1_MC"},
     {"2017", "Summer20UL17NanoV15_V1_MC"},
     {"2018", "Summer20UL18NanoV15_V1_MC"},
-    {"2022Re-recoBCD", "Summer22_22Sep2023_V3_MC"},
-    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_V3_MC"},
-    {"2023PromptC", "Summer23Prompt23_V3_MC"},
-    {"2023PromptD", "Summer23BPixPrompt23_V3_MC"},
-    {"2024Prompt", "Summer24Prompt24_V2_MC"}
+    {"2022Re-recoBCD", "Summer22_22Sep2023_V4_MC"},
+    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_V4_MC"},
+    {"2023PromptC", "Summer23Prompt23_V4_MC"},
+    {"2023PromptD", "Summer23BPixPrompt23_V4_MC"},
+    {"2024Prompt", "Summer24Prompt24_V4_MC"},
+    {"2025", "Summer24Prompt25_V2_MC"}
 };
 
 const std::unordered_map<std::string, std::string> jetEnergyCorrections_JEC_suffix = {
@@ -208,7 +239,8 @@ const std::unordered_map<std::string, std::string> jetEnergyCorrections_JEC_suff
     {"2022Re-recoE+PromptFG", "AK4PFPuppi"},
     {"2023PromptC", "AK4PFPuppi"},
     {"2023PromptD", "AK4PFPuppi"},
-    {"2024Prompt", "AK4PFPuppi"}
+    {"2024Prompt", "AK4PFPuppi"},
+    {"2025", "AK4PFPuppi"}
 };
 
 // AK8 fat-jet variants — same year keys, AK8PFPuppi algo across all eras.
@@ -217,11 +249,12 @@ const std::unordered_map<std::string, std::string> fatJetEnergyCorrections_JEC_p
     {"2016postVFP", "Summer20UL16NanoV15_V1_MC"},
     {"2017", "Summer20UL17NanoV15_V1_MC"},
     {"2018", "Summer20UL18NanoV15_V1_MC"},
-    {"2022Re-recoBCD", "Summer22_22Sep2023_V3_MC"},
-    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_V3_MC"},
-    {"2023PromptC", "Summer23Prompt23_V3_MC"},
-    {"2023PromptD", "Summer23BPixPrompt23_V3_MC"},
-    {"2024Prompt", "Summer24Prompt24_V2_MC"}
+    {"2022Re-recoBCD", "Summer22_22Sep2023_V4_MC"},
+    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_V4_MC"},
+    {"2023PromptC", "Summer23Prompt23_V4_MC"},
+    {"2023PromptD", "Summer23BPixPrompt23_V4_MC"},
+    {"2024Prompt", "Summer24Prompt24_V4_MC"},
+    {"2025", "Summer24Prompt25_V2_MC"}
 };
 
 const std::unordered_map<std::string, std::string> fatJetEnergyCorrections_JEC_suffix = {
@@ -233,7 +266,8 @@ const std::unordered_map<std::string, std::string> fatJetEnergyCorrections_JEC_s
     {"2022Re-recoE+PromptFG", "AK8PFPuppi"},
     {"2023PromptC", "AK8PFPuppi"},
     {"2023PromptD", "AK8PFPuppi"},
-    {"2024Prompt", "AK8PFPuppi"}
+    {"2024Prompt", "AK8PFPuppi"},
+    {"2025", "AK8PFPuppi"}
 };
 
 // Year token embedded in the year-decorrelated Regrouped JEC source names
@@ -248,63 +282,77 @@ const std::unordered_map<std::string, std::string> jetEnergyCorrections_yearToke
     {"2022Re-recoE+PromptFG", "2022EE"},
     {"2023PromptC", "2023"},
     {"2023PromptD", "2023BPix"},
-    {"2024Prompt", "2024"}
+    {"2024Prompt", "2024"},
+    {"2025", "2025"}
 };
 
-// JER tag names 
-// FIXME: 2024 re-uses the 2023BPix JR until a dedicated 2024 release lands
+// JER tag names — pinned per era (see JEC section header): Run 2 + 2022/2023 on the
+// 2026-06-05 snapshot, 2024Prompt + 2025 on the 2026-07-14 snapshot.
+// 2024 ships a dedicated Summer24Prompt24_JRV2 release (no longer reusing 2023BPix).
 const std::unordered_map<std::string, std::string> jetEnergyResolution_JER_res_name = {
-    {"2016preVFP", "Summer20UL16APV_JRV3_MC_PtResolution_AK4PFPuppi"},
-    {"2016postVFP", "Summer20UL16_JRV3_MC_PtResolution_AK4PFPuppi"},
-    {"2017", "Summer19UL17_JRV3_MC_PtResolution_AK4PFPuppi"},
-    {"2018", "Summer19UL18_JRV2_MC_PtResolution_AK4PFPuppi"},
-    {"2022Re-recoBCD", "Summer22_22Sep2023_JRV1_MC_PtResolution_AK4PFPuppi"},
-    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_JRV1_MC_PtResolution_AK4PFPuppi"},
-    {"2023PromptC", "Summer23Prompt23_RunCv1234_JRV1_MC_PtResolution_AK4PFPuppi"},
-    {"2023PromptD", "Summer23BPixPrompt23_RunD_JRV1_MC_PtResolution_AK4PFPuppi"},
-    {"2024Prompt", "Summer23BPixPrompt23_RunD_JRV1_MC_PtResolution_AK4PFPuppi"}
+    {"2016preVFP", "Summer20UL16APV_JRV5_MC_PtResolution_AK4PFPuppi"},
+    {"2016postVFP", "Summer20UL16_JRV5_MC_PtResolution_AK4PFPuppi"},
+    {"2017", "Summer19UL17_JRV4_MC_PtResolution_AK4PFPuppi"},
+    {"2018", "Summer19UL18_JRV3_MC_PtResolution_AK4PFPuppi"},
+    {"2022Re-recoBCD", "Summer22_22Sep2023_JRV2_MC_PtResolution_AK4PFPuppi"},
+    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_JRV2_MC_PtResolution_AK4PFPuppi"},
+    {"2023PromptC", "Summer23Prompt23_RunCv1234_JRV2_MC_PtResolution_AK4PFPuppi"},
+    {"2023PromptD", "Summer23BPixPrompt23_RunD_JRV2_MC_PtResolution_AK4PFPuppi"},
+    {"2024Prompt", "Summer24Prompt24_JRV2_MC_PtResolution_AK4PFPuppi"},
+    {"2025", "Summer24Prompt25_JRV2_MC_PtResolution_AK4PFPuppi"}
 };
 
 const std::unordered_map<std::string, std::string> jetEnergyResolution_JER_sf_name = {
-    {"2016preVFP", "Summer20UL16APV_JRV3_MC_ScaleFactor_AK4PFPuppi"},
-    {"2016postVFP", "Summer20UL16_JRV3_MC_ScaleFactor_AK4PFPuppi"},
-    {"2017", "Summer19UL17_JRV3_MC_ScaleFactor_AK4PFPuppi"},
-    {"2018", "Summer19UL18_JRV2_MC_ScaleFactor_AK4PFPuppi"},
-    {"2022Re-recoBCD", "Summer22_22Sep2023_JRV1_MC_ScaleFactor_AK4PFPuppi"},
-    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_JRV1_MC_ScaleFactor_AK4PFPuppi"},
-    {"2023PromptC", "Summer23Prompt23_RunCv1234_JRV1_MC_ScaleFactor_AK4PFPuppi"},
-    {"2023PromptD", "Summer23BPixPrompt23_RunD_JRV1_MC_ScaleFactor_AK4PFPuppi"},
-    {"2024Prompt", "Summer23BPixPrompt23_RunD_JRV1_MC_ScaleFactor_AK4PFPuppi"}
+    {"2016preVFP", "Summer20UL16APV_JRV5_MC_ScaleFactor_AK4PFPuppi"},
+    {"2016postVFP", "Summer20UL16_JRV5_MC_ScaleFactor_AK4PFPuppi"},
+    {"2017", "Summer19UL17_JRV4_MC_ScaleFactor_AK4PFPuppi"},
+    {"2018", "Summer19UL18_JRV3_MC_ScaleFactor_AK4PFPuppi"},
+    {"2022Re-recoBCD", "Summer22_22Sep2023_JRV2_MC_ScaleFactor_AK4PFPuppi"},
+    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_JRV2_MC_ScaleFactor_AK4PFPuppi"},
+    {"2023PromptC", "Summer23Prompt23_RunCv1234_JRV2_MC_ScaleFactor_AK4PFPuppi"},
+    {"2023PromptD", "Summer23BPixPrompt23_RunD_JRV2_MC_ScaleFactor_AK4PFPuppi"},
+    {"2024Prompt", "Summer24Prompt24_JRV2_MC_ScaleFactor_AK4PFPuppi"},
+    {"2025", "Summer24Prompt25_JRV2_MC_ScaleFactor_AK4PFPuppi"}
 };
 
 // AK8 JER tags — same JR releases as AK4 but with AK8PFPuppi algo.
 const std::unordered_map<std::string, std::string> fatJetEnergyResolution_JER_res_name = {
-    {"2016preVFP", "Summer20UL16APV_JRV3_MC_PtResolution_AK8PFPuppi"},
-    {"2016postVFP", "Summer20UL16_JRV3_MC_PtResolution_AK8PFPuppi"},
-    {"2017", "Summer19UL17_JRV3_MC_PtResolution_AK8PFPuppi"},
-    {"2018", "Summer19UL18_JRV2_MC_PtResolution_AK8PFPuppi"},
-    {"2022Re-recoBCD", "Summer22_22Sep2023_JRV1_MC_PtResolution_AK8PFPuppi"},
-    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_JRV1_MC_PtResolution_AK8PFPuppi"},
-    {"2023PromptC", "Summer23Prompt23_RunCv1234_JRV1_MC_PtResolution_AK8PFPuppi"},
-    {"2023PromptD", "Summer23BPixPrompt23_RunD_JRV1_MC_PtResolution_AK8PFPuppi"},
-    {"2024Prompt", "Summer23BPixPrompt23_RunD_JRV1_MC_PtResolution_AK8PFPuppi"}
+    {"2016preVFP", "Summer20UL16APV_JRV5_MC_PtResolution_AK8PFPuppi"},
+    {"2016postVFP", "Summer20UL16_JRV5_MC_PtResolution_AK8PFPuppi"},
+    {"2017", "Summer19UL17_JRV4_MC_PtResolution_AK8PFPuppi"},
+    {"2018", "Summer19UL18_JRV3_MC_PtResolution_AK8PFPuppi"},
+    {"2022Re-recoBCD", "Summer22_22Sep2023_JRV2_MC_PtResolution_AK8PFPuppi"},
+    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_JRV2_MC_PtResolution_AK8PFPuppi"},
+    {"2023PromptC", "Summer23Prompt23_RunCv1234_JRV2_MC_PtResolution_AK8PFPuppi"},
+    {"2023PromptD", "Summer23BPixPrompt23_RunD_JRV2_MC_PtResolution_AK8PFPuppi"},
+    {"2024Prompt", "Summer24Prompt24_JRV2_MC_PtResolution_AK8PFPuppi"},
+    {"2025", "Summer24Prompt25_JRV2_MC_PtResolution_AK8PFPuppi"}
 };
 
 const std::unordered_map<std::string, std::string> fatJetEnergyResolution_JER_sf_name = {
-    {"2016preVFP", "Summer20UL16APV_JRV3_MC_ScaleFactor_AK8PFPuppi"},
-    {"2016postVFP", "Summer20UL16_JRV3_MC_ScaleFactor_AK8PFPuppi"},
-    {"2017", "Summer19UL17_JRV3_MC_ScaleFactor_AK8PFPuppi"},
-    {"2018", "Summer19UL18_JRV2_MC_ScaleFactor_AK8PFPuppi"},
-    {"2022Re-recoBCD", "Summer22_22Sep2023_JRV1_MC_ScaleFactor_AK8PFPuppi"},
-    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_JRV1_MC_ScaleFactor_AK8PFPuppi"},
-    {"2023PromptC", "Summer23Prompt23_RunCv1234_JRV1_MC_ScaleFactor_AK8PFPuppi"},
-    {"2023PromptD", "Summer23BPixPrompt23_RunD_JRV1_MC_ScaleFactor_AK8PFPuppi"},
-    {"2024Prompt", "Summer23BPixPrompt23_RunD_JRV1_MC_ScaleFactor_AK8PFPuppi"}
+    {"2016preVFP", "Summer20UL16APV_JRV5_MC_ScaleFactor_AK8PFPuppi"},
+    {"2016postVFP", "Summer20UL16_JRV5_MC_ScaleFactor_AK8PFPuppi"},
+    {"2017", "Summer19UL17_JRV4_MC_ScaleFactor_AK8PFPuppi"},
+    {"2018", "Summer19UL18_JRV3_MC_ScaleFactor_AK8PFPuppi"},
+    {"2022Re-recoBCD", "Summer22_22Sep2023_JRV2_MC_ScaleFactor_AK8PFPuppi"},
+    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_JRV2_MC_ScaleFactor_AK8PFPuppi"},
+    {"2023PromptC", "Summer23Prompt23_RunCv1234_JRV2_MC_ScaleFactor_AK8PFPuppi"},
+    {"2023PromptD", "Summer23BPixPrompt23_RunD_JRV2_MC_ScaleFactor_AK8PFPuppi"},
+    {"2024Prompt", "Summer24Prompt24_JRV2_MC_ScaleFactor_AK8PFPuppi"},
+    {"2025", "Summer24Prompt25_JRV2_MC_ScaleFactor_AK8PFPuppi"}
 };
+
+// Full Type-1 PuppiMET rebuild from RawPuppiMET over the merged AK4 list (Jet + CorrT1METJet)
+// with muon subtraction, per the JERC recipe. Writes met_pt / met_phi (nominal) and, on MC with
+// systematics enabled, met_pt_<sfx> / met_phi_<sfx> for each JES variation. Must run AFTER
+// applyJetEnergyCorrections / applyJetEnergyResolution / applyJESVariations (it consumes
+// Jet_jerFactor and the _Jet_shift_<sfx> columns and re-evaluates the JEC compound) and after
+// _Jet_rawpt = (1-Jet_rawFactor)*Jet_pt has been defined on the pristine NanoAOD jets.
+RNode applyType1MET(RNode df, bool isData);
 
 // Nominal JEC: removes the JEC stored in NanoAOD (via Jet_rawFactor) and re-applies the
 // latest L1FastJet * L2Relative * L3Absolute (* L2L3Residual for data) compound from
-// jet_jerc.json.gz. Propagates the change to met_pt / met_phi (Type-I).
+// jet_jerc.json.gz. MET is NOT propagated here — it is rebuilt in applyType1MET.
 RNode applyJetEnergyCorrections(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
                                 const std::unordered_map<std::string, std::string>& jec_prefix_map,
                                 const std::unordered_map<std::string, std::string>& jec_suffix_map,

--- a/preselection/src/corrections.h
+++ b/preselection/src/corrections.h
@@ -3,23 +3,30 @@
 
 #pragma once
 
-#include <unordered_map>
 #include <string>
-#include <iostream>
+#include <unordered_map>
 #include <vector>
-#include <array>
-#include <stdexcept>
 
 #include "ROOT/RDataFrame.hxx"
 #include "ROOT/RDFHelpers.hxx"
 #include "ROOT/RVec.hxx"
 
 #include "correction.h"
-#include "TRandom3.h"
 
 using correction::CorrectionSet;
 using RNode = ROOT::RDF::RNode;
 using ROOT::VecOps::RVec;
+
+/*
+############################################
+CORRECTION DATA REGISTRY
+############################################
+
+All correctionlib payloads (CorrectionSet::from_file) and the era-keyed
+tag/name tables live in corrections.cpp — see the CORRECTION-SET REGISTRY
+section there. Single definition point, loaded lazily on first use.
+To add or re-pin an era, edit the JERC era table in corrections.cpp.
+*/
 
 /*
 ############################################
@@ -30,78 +37,11 @@ RVec<bool> isbTagLoose(std::string year, RVec<float> btag_score);
 RVec<bool> isbTagMedium(std::string year, RVec<float> btag_score);
 RVec<bool> isbTagTight(std::string year, RVec<float> btag_score);
 
-
-// Note: Re-using 2024 WPs for 2022-2023
-const std::unordered_map <std::string, correction::CorrectionSet> btaggingCorrections = {
-    {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run2-2016preVFP-UL-NanoAODv15/latest/btagging.json.gz")},
-    {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run2-2016postVFP-UL-NanoAODv15/latest/btagging.json.gz")},
-    {"2017", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run2-2017-UL-NanoAODv15/latest/btagging.json.gz")},
-    {"2018", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run2-2018-UL-NanoAODv15/latest/btagging.json.gz")},
-    {"2022Re-recoBCD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/latest/btagging.json.gz")},
-    {"2022Re-recoE+PromptFG", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/latest/btagging.json.gz")},
-    {"2023PromptC", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/latest/btagging.json.gz")},
-    {"2023PromptD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/latest/btagging.json.gz")},
-    {"2024Prompt", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/latest/btagging.json.gz")},
-    // Recomendation from: https://btv-wiki.docs.cern.ch/ScaleFactors/Run3Prompt25/
-    {"2025", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-25Prompt-Summer24-NanoAODv15/latest/btagging.json.gz")}
-};
-
-// 2. Map of Numbers: Put the actual numeric thresholds here
-static std::unordered_map<std::string, float> btaggingWPMap_Loose = {
-    {"2016preVFP",  btaggingCorrections.at("2016preVFP").at("UParTAK4_wp_values")->evaluate({"L"})}, 
-    {"2016postVFP", btaggingCorrections.at("2016postVFP").at("UParTAK4_wp_values")->evaluate({"L"})},
-    {"2017",        btaggingCorrections.at("2017").at("UParTAK4_wp_values")->evaluate({"L"})},
-    {"2018",        btaggingCorrections.at("2018").at("UParTAK4_wp_values")->evaluate({"L"})},
-    {"2022Re-recoBCD", btaggingCorrections.at("2022Re-recoBCD").at("UParTAK4_wp_values")->evaluate({"L"})},
-    {"2022Re-recoE+PromptFG", btaggingCorrections.at("2022Re-recoE+PromptFG").at("UParTAK4_wp_values")->evaluate({"L"})},
-    {"2023PromptC", btaggingCorrections.at("2023PromptC").at("UParTAK4_wp_values")->evaluate({"L"})},
-    {"2023PromptD", btaggingCorrections.at("2023PromptD").at("UParTAK4_wp_values")->evaluate({"L"})},
-    {"2024Prompt",  btaggingCorrections.at("2024Prompt").at("UParTAK4_wp_values")->evaluate({"L"})},
-    {"2025",        btaggingCorrections.at("2025").at("UParTAK4_wp_values")->evaluate({"L"})}
-};
-
-static std::unordered_map<std::string, float> btaggingWPMap_Medium = {
-    {"2016preVFP",  btaggingCorrections.at("2016preVFP").at("UParTAK4_wp_values")->evaluate({"M"})},
-    {"2016postVFP", btaggingCorrections.at("2016postVFP").at("UParTAK4_wp_values")->evaluate({"M"})},
-    {"2017",        btaggingCorrections.at("2017").at("UParTAK4_wp_values")->evaluate({"M"})},
-    {"2018",        btaggingCorrections.at("2018").at("UParTAK4_wp_values")->evaluate({"M"})},
-    {"2022Re-recoBCD", btaggingCorrections.at("2022Re-recoBCD").at("UParTAK4_wp_values")->evaluate({"M"})},
-    {"2022Re-recoE+PromptFG", btaggingCorrections.at("2022Re-recoE+PromptFG").at("UParTAK4_wp_values")->evaluate({"M"})},
-    {"2023PromptC", btaggingCorrections.at("2023PromptC").at("UParTAK4_wp_values")->evaluate({"M"})},
-    {"2023PromptD", btaggingCorrections.at("2023PromptD").at("UParTAK4_wp_values")->evaluate({"M"})},
-    {"2024Prompt",  btaggingCorrections.at("2024Prompt").at("UParTAK4_wp_values")->evaluate({"M"})},
-    {"2025",        btaggingCorrections.at("2025").at("UParTAK4_wp_values")->evaluate({"M"})}
-};
-
-static std::unordered_map<std::string, float> btaggingWPMap_Tight = {
-    {"2016preVFP",  btaggingCorrections.at("2016preVFP").at("UParTAK4_wp_values")->evaluate({"T"})},
-    {"2016postVFP", btaggingCorrections.at("2016postVFP").at("UParTAK4_wp_values")->evaluate({"T"})},
-    {"2017",        btaggingCorrections.at("2017").at("UParTAK4_wp_values")->evaluate({"T"})},
-    {"2018",        btaggingCorrections.at("2018").at("UParTAK4_wp_values")->evaluate({"T"})},
-    {"2022Re-recoBCD", btaggingCorrections.at("2022Re-recoBCD").at("UParTAK4_wp_values")->evaluate({"T"})},
-    {"2022Re-recoE+PromptFG", btaggingCorrections.at("2022Re-recoE+PromptFG").at("UParTAK4_wp_values")->evaluate({"T"})},
-    {"2023PromptC", btaggingCorrections.at("2023PromptC").at("UParTAK4_wp_values")->evaluate({"T"})},
-    {"2023PromptD", btaggingCorrections.at("2023PromptD").at("UParTAK4_wp_values")->evaluate({"T"})},
-    {"2024Prompt",  btaggingCorrections.at("2024Prompt").at("UParTAK4_wp_values")->evaluate({"T"})},
-    {"2025",        btaggingCorrections.at("2025").at("UParTAK4_wp_values")->evaluate({"T"})}
-};
-
 /*
 ############################################
 MET CORRECTIONS
 ############################################
 */
-// FIXME: met corrections missing for v15
-const std::unordered_map<std::string, correction::CorrectionSet> metCorrections = {
-    {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016preVFP-UL-NanoAODv9/latest/met.json.gz")},
-    {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016postVFP-UL-NanoAODv9/latest/met.json.gz")},
-    {"2017", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2017-UL-NanoAODv9/latest/met.json.gz")},
-    {"2018", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2018-UL-NanoAODv9/latest/met.json.gz")},
-    // {"2022Re-recoBCD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/latest/met_xyCorrections_2022_2022.json.gz")},
-    // {"2022Re-recoE+PromptFG", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22EFGSep23-Summer22EE-NanoAODv12/latest/met_xyCorrections_2022_2022EE.json.gz")},
-    // {"2023PromptC", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23CSep23-Summer23-NanoAODv12/latest/met_xyCorrections_2023_2023.json.gz")},
-    // {"2023PromptD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23DSep23-Summer23BPix-NanoAODv12/latest/met_xyCorrections_2023_2023BPix.json.gz")}
-};
 RNode applyMETPhiCorrections(RNode df, bool isData);
 RNode applyMETUnclusteredCorrections(RNode df, std::string variation);
 
@@ -118,38 +58,9 @@ applyJetMassScale / applyJetMassResolution (corrections.cpp) are column-agnostic
 mass branch and (for JMR) the gen mass + gen-index branches are passed in. This
 analysis intends to calibrate on the GloParT regressed mass, not FatJet_msoftdrop
 (see CORRECTIONS.md § 5-6), and the calibration is not yet derived — the helpers
-are currently unwired in applyMCCorrections.
-
-The maps below are identity-valued placeholders kept as a template; the GloParT
-calibration will supply its own per-era shift / factor / σ_rel maps. Up/down
-systematic variants come from passing ±1σ shift/scale.
+are currently unwired in applyMCCorrections. Identity-valued placeholder maps
+(a template for the future calibration) live in corrections.cpp.
 */
-
-const std::unordered_map<std::string, float> jetMassScale_central = {
-    {"2016preVFP", 0.0f}, {"2016postVFP", 0.0f}, {"2017", 0.0f}, {"2018", 0.0f},
-    {"2022Re-recoBCD", 0.0f}, {"2022Re-recoE+PromptFG", 0.0f},
-    {"2023PromptC", 0.0f}, {"2023PromptD", 0.0f},
-    {"2024Prompt", 0.0f}
-};
-
-const std::unordered_map<std::string, float> jetMassResolution_central = {
-    {"2016preVFP", 1.0f}, {"2016postVFP", 1.0f}, {"2017", 1.0f}, {"2018", 1.0f},
-    {"2022Re-recoBCD", 1.0f}, {"2022Re-recoE+PromptFG", 1.0f},
-    {"2023PromptC", 1.0f}, {"2023PromptD", 1.0f},
-    {"2024Prompt", 1.0f}
-};
-
-// Relative mass resolution sigma(m)/m used by the unmatched stochastic branch of
-// applyJetMassResolution. Placeholder 1.0 — replace with the per-era value from the same
-// calibration fit that derives jetMassResolution_central. With factor f = 1.0 (placeholder)
-// the branch is unreachable, so this value has no effect until both maps are updated together.
-const std::unordered_map<std::string, float> jetMassResolution_sigmaRel_central = {
-    {"2016preVFP", 1.0f}, {"2016postVFP", 1.0f}, {"2017", 1.0f}, {"2018", 1.0f},
-    {"2022Re-recoBCD", 1.0f}, {"2022Re-recoE+PromptFG", 1.0f},
-    {"2023PromptC", 1.0f}, {"2023PromptD", 1.0f},
-    {"2024Prompt", 1.0f}
-};
-
 RNode applyJetMassScale(const std::unordered_map<std::string, float>& shift_map,
                      const std::string& mass_col, RNode df);
 RNode applyJetMassResolution(const std::unordered_map<std::string, float>& factor_map,
@@ -164,189 +75,15 @@ RNode applyJetMassResolution(const std::unordered_map<std::string, float>& facto
 JET ENERGY CORRECTIONS
 ############################################
 
-Run 2 + the 2022/2023 Run 3 eras are pinned to the 2026-06-05 JME snapshot (jet_jerc /
-fatJet_jerc); the 2024Prompt and 2025 eras are pinned to the newer 2026-07-14 snapshot
-(JEC V4/V2, JER JRV2 — see below). JER-Smearing is pinned to 2025-11-03 — NOT the mutable
-`latest/` symlink. The tag strings below are the compound/correction keys that exist inside
-those pinned files. The "2024Prompt" era uses the Summer24Prompt24 tag (JEC V4 / JER JRV2),
-and the "2025" era (2025 data + Summer24 MC) uses the JME-recommended Summer24Prompt25 tag
-(JEC V2 / JER JRV2), both pinned to the 2026-07-14 snapshot. The 2026-07-14 update moved the
-L2L3Residual corrections to signed-η (from |η|) and refreshed the JER SFs; evalJECCompound
-already passes signed eta and resolves inputs by name, so no code change was needed.
-correctionlib has no "give me the newest version" API: the code asks
-for a tag by name, so the file version and the requested tag string must be bumped
-together, deliberately, in one commit. Loading from `latest/` while pinning the tag
-string is what previously let the two drift apart (V3 code vs V4 file -> silent no-op;
-now a hard error, see applyJetEnergyCorrections in corrections.cpp). To adopt a newer
-JME release: pick the new dated dir, find the new recommended tag, and update both
-the paths and the tag maps here.
-
-JES
+The pinned correction files and per-era JEC/JER tag strings are defined by the
+JERC era table in corrections.cpp (see the pinning rationale documented there).
 */
-const std::unordered_map<std::string, correction::CorrectionSet> jetEnergyCorrections = {
-    {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016preVFP-UL-NanoAODv15/2026-06-05/jet_jerc.json.gz")},
-    {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016postVFP-UL-NanoAODv15/2026-06-05/jet_jerc.json.gz")},
-    {"2017", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2017-UL-NanoAODv15/2026-06-05/jet_jerc.json.gz")},
-    {"2018", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2018-UL-NanoAODv15/2026-06-05/jet_jerc.json.gz")},
-    {"2022Re-recoBCD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/2026-06-05/jet_jerc.json.gz")},
-    {"2022Re-recoE+PromptFG", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22EFGSep23-Summer22EE-NanoAODv12/2026-06-05/jet_jerc.json.gz")},
-    {"2023PromptC", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23CSep23-Summer23-NanoAODv12/2026-06-05/jet_jerc.json.gz")},
-    {"2023PromptD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23DSep23-Summer23BPix-NanoAODv12/2026-06-05/jet_jerc.json.gz")},
-    {"2024Prompt", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2026-07-14/jet_jerc.json.gz")},
-    // 2025 data + Summer24 MC — JME-recommended Summer24Prompt25 (JEC + JER + JES self-contained); pinned to 2026-07-03.
-    {"2025", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-25Prompt-Summer24-NanoAODv15/2026-07-14/jet_jerc.json.gz")}
-};
-
-// AK8 fat-jet JEC/JER lives in fatJet_jerc.json.gz under the same era directories.
-const std::unordered_map<std::string, correction::CorrectionSet> fatJetEnergyCorrections = {
-    {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016preVFP-UL-NanoAODv15/2026-06-05/fatJet_jerc.json.gz")},
-    {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016postVFP-UL-NanoAODv15/2026-06-05/fatJet_jerc.json.gz")},
-    {"2017", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2017-UL-NanoAODv15/2026-06-05/fatJet_jerc.json.gz")},
-    {"2018", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2018-UL-NanoAODv15/2026-06-05/fatJet_jerc.json.gz")},
-    {"2022Re-recoBCD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/2026-06-05/fatJet_jerc.json.gz")},
-    {"2022Re-recoE+PromptFG", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22EFGSep23-Summer22EE-NanoAODv12/2026-06-05/fatJet_jerc.json.gz")},
-    {"2023PromptC", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23CSep23-Summer23-NanoAODv12/2026-06-05/fatJet_jerc.json.gz")},
-    {"2023PromptD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23DSep23-Summer23BPix-NanoAODv12/2026-06-05/fatJet_jerc.json.gz")},
-    {"2024Prompt", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2026-07-14/fatJet_jerc.json.gz")},
-    {"2025", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-25Prompt-Summer24-NanoAODv15/2026-07-14/fatJet_jerc.json.gz")}
-};
-
-const std::unordered_map<std::string, correction::CorrectionSet> jetEnergyResolution_smear = {
-    {"jer_smear", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/JER-Smearing/2025-11-03/jer_smear.json.gz")}
-};
-
-// JEC tag base — `<TAG>_MC` and `<TAG>_DATA` compounds (`_L1L2L3Res_<algo>`) live in jet_jerc.json.gz.
-// The trailing `_MC` here is stripped and replaced with `_DATA` at runtime when running on data.
-const std::unordered_map<std::string, std::string> jetEnergyCorrections_JEC_prefix = {
-    {"2016preVFP", "Summer20UL16APVNanoV15_V1_MC"},
-    {"2016postVFP", "Summer20UL16NanoV15_V1_MC"},
-    {"2017", "Summer20UL17NanoV15_V1_MC"},
-    {"2018", "Summer20UL18NanoV15_V1_MC"},
-    {"2022Re-recoBCD", "Summer22_22Sep2023_V4_MC"},
-    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_V4_MC"},
-    {"2023PromptC", "Summer23Prompt23_V4_MC"},
-    {"2023PromptD", "Summer23BPixPrompt23_V4_MC"},
-    {"2024Prompt", "Summer24Prompt24_V4_MC"},
-    {"2025", "Summer24Prompt25_V2_MC"}
-};
-
-const std::unordered_map<std::string, std::string> jetEnergyCorrections_JEC_suffix = {
-    {"2016preVFP", "AK4PFPuppi"},
-    {"2016postVFP", "AK4PFPuppi"},
-    {"2017", "AK4PFPuppi"},
-    {"2018", "AK4PFPuppi"},
-    {"2022Re-recoBCD", "AK4PFPuppi"},
-    {"2022Re-recoE+PromptFG", "AK4PFPuppi"},
-    {"2023PromptC", "AK4PFPuppi"},
-    {"2023PromptD", "AK4PFPuppi"},
-    {"2024Prompt", "AK4PFPuppi"},
-    {"2025", "AK4PFPuppi"}
-};
-
-// AK8 fat-jet variants — same year keys, AK8PFPuppi algo across all eras.
-const std::unordered_map<std::string, std::string> fatJetEnergyCorrections_JEC_prefix = {
-    {"2016preVFP", "Summer20UL16APVNanoV15_V1_MC"},
-    {"2016postVFP", "Summer20UL16NanoV15_V1_MC"},
-    {"2017", "Summer20UL17NanoV15_V1_MC"},
-    {"2018", "Summer20UL18NanoV15_V1_MC"},
-    {"2022Re-recoBCD", "Summer22_22Sep2023_V4_MC"},
-    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_V4_MC"},
-    {"2023PromptC", "Summer23Prompt23_V4_MC"},
-    {"2023PromptD", "Summer23BPixPrompt23_V4_MC"},
-    {"2024Prompt", "Summer24Prompt24_V4_MC"},
-    {"2025", "Summer24Prompt25_V2_MC"}
-};
-
-const std::unordered_map<std::string, std::string> fatJetEnergyCorrections_JEC_suffix = {
-    {"2016preVFP", "AK8PFPuppi"},
-    {"2016postVFP", "AK8PFPuppi"},
-    {"2017", "AK8PFPuppi"},
-    {"2018", "AK8PFPuppi"},
-    {"2022Re-recoBCD", "AK8PFPuppi"},
-    {"2022Re-recoE+PromptFG", "AK8PFPuppi"},
-    {"2023PromptC", "AK8PFPuppi"},
-    {"2023PromptD", "AK8PFPuppi"},
-    {"2024Prompt", "AK8PFPuppi"},
-    {"2025", "AK8PFPuppi"}
-};
-
-// Year token embedded in the year-decorrelated Regrouped JEC source names
-// (e.g. "Summer20UL18NanoV15_V1_MC_Regrouped_Absolute_2018_AK4PFPuppi"). Confirmed
-// against jet_jerc.json.gz / fatJet_jerc.json.gz for every campaign on 2026-05-14.
-const std::unordered_map<std::string, std::string> jetEnergyCorrections_yearToken = {
-    {"2016preVFP", "2016APV"},
-    {"2016postVFP", "2016"},
-    {"2017", "2017"},
-    {"2018", "2018"},
-    {"2022Re-recoBCD", "2022"},
-    {"2022Re-recoE+PromptFG", "2022EE"},
-    {"2023PromptC", "2023"},
-    {"2023PromptD", "2023BPix"},
-    {"2024Prompt", "2024"},
-    {"2025", "2025"}
-};
-
-// JER tag names — pinned per era (see JEC section header): Run 2 + 2022/2023 on the
-// 2026-06-05 snapshot, 2024Prompt + 2025 on the 2026-07-14 snapshot.
-// 2024 ships a dedicated Summer24Prompt24_JRV2 release (no longer reusing 2023BPix).
-const std::unordered_map<std::string, std::string> jetEnergyResolution_JER_res_name = {
-    {"2016preVFP", "Summer20UL16APV_JRV5_MC_PtResolution_AK4PFPuppi"},
-    {"2016postVFP", "Summer20UL16_JRV5_MC_PtResolution_AK4PFPuppi"},
-    {"2017", "Summer19UL17_JRV4_MC_PtResolution_AK4PFPuppi"},
-    {"2018", "Summer19UL18_JRV3_MC_PtResolution_AK4PFPuppi"},
-    {"2022Re-recoBCD", "Summer22_22Sep2023_JRV2_MC_PtResolution_AK4PFPuppi"},
-    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_JRV2_MC_PtResolution_AK4PFPuppi"},
-    {"2023PromptC", "Summer23Prompt23_RunCv1234_JRV2_MC_PtResolution_AK4PFPuppi"},
-    {"2023PromptD", "Summer23BPixPrompt23_RunD_JRV2_MC_PtResolution_AK4PFPuppi"},
-    {"2024Prompt", "Summer24Prompt24_JRV2_MC_PtResolution_AK4PFPuppi"},
-    {"2025", "Summer24Prompt25_JRV2_MC_PtResolution_AK4PFPuppi"}
-};
-
-const std::unordered_map<std::string, std::string> jetEnergyResolution_JER_sf_name = {
-    {"2016preVFP", "Summer20UL16APV_JRV5_MC_ScaleFactor_AK4PFPuppi"},
-    {"2016postVFP", "Summer20UL16_JRV5_MC_ScaleFactor_AK4PFPuppi"},
-    {"2017", "Summer19UL17_JRV4_MC_ScaleFactor_AK4PFPuppi"},
-    {"2018", "Summer19UL18_JRV3_MC_ScaleFactor_AK4PFPuppi"},
-    {"2022Re-recoBCD", "Summer22_22Sep2023_JRV2_MC_ScaleFactor_AK4PFPuppi"},
-    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_JRV2_MC_ScaleFactor_AK4PFPuppi"},
-    {"2023PromptC", "Summer23Prompt23_RunCv1234_JRV2_MC_ScaleFactor_AK4PFPuppi"},
-    {"2023PromptD", "Summer23BPixPrompt23_RunD_JRV2_MC_ScaleFactor_AK4PFPuppi"},
-    {"2024Prompt", "Summer24Prompt24_JRV2_MC_ScaleFactor_AK4PFPuppi"},
-    {"2025", "Summer24Prompt25_JRV2_MC_ScaleFactor_AK4PFPuppi"}
-};
-
-// AK8 JER tags — same JR releases as AK4 but with AK8PFPuppi algo.
-const std::unordered_map<std::string, std::string> fatJetEnergyResolution_JER_res_name = {
-    {"2016preVFP", "Summer20UL16APV_JRV5_MC_PtResolution_AK8PFPuppi"},
-    {"2016postVFP", "Summer20UL16_JRV5_MC_PtResolution_AK8PFPuppi"},
-    {"2017", "Summer19UL17_JRV4_MC_PtResolution_AK8PFPuppi"},
-    {"2018", "Summer19UL18_JRV3_MC_PtResolution_AK8PFPuppi"},
-    {"2022Re-recoBCD", "Summer22_22Sep2023_JRV2_MC_PtResolution_AK8PFPuppi"},
-    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_JRV2_MC_PtResolution_AK8PFPuppi"},
-    {"2023PromptC", "Summer23Prompt23_RunCv1234_JRV2_MC_PtResolution_AK8PFPuppi"},
-    {"2023PromptD", "Summer23BPixPrompt23_RunD_JRV2_MC_PtResolution_AK8PFPuppi"},
-    {"2024Prompt", "Summer24Prompt24_JRV2_MC_PtResolution_AK8PFPuppi"},
-    {"2025", "Summer24Prompt25_JRV2_MC_PtResolution_AK8PFPuppi"}
-};
-
-const std::unordered_map<std::string, std::string> fatJetEnergyResolution_JER_sf_name = {
-    {"2016preVFP", "Summer20UL16APV_JRV5_MC_ScaleFactor_AK8PFPuppi"},
-    {"2016postVFP", "Summer20UL16_JRV5_MC_ScaleFactor_AK8PFPuppi"},
-    {"2017", "Summer19UL17_JRV4_MC_ScaleFactor_AK8PFPuppi"},
-    {"2018", "Summer19UL18_JRV3_MC_ScaleFactor_AK8PFPuppi"},
-    {"2022Re-recoBCD", "Summer22_22Sep2023_JRV2_MC_ScaleFactor_AK8PFPuppi"},
-    {"2022Re-recoE+PromptFG", "Summer22EE_22Sep2023_JRV2_MC_ScaleFactor_AK8PFPuppi"},
-    {"2023PromptC", "Summer23Prompt23_RunCv1234_JRV2_MC_ScaleFactor_AK8PFPuppi"},
-    {"2023PromptD", "Summer23BPixPrompt23_RunD_JRV2_MC_ScaleFactor_AK8PFPuppi"},
-    {"2024Prompt", "Summer24Prompt24_JRV2_MC_ScaleFactor_AK8PFPuppi"},
-    {"2025", "Summer24Prompt25_JRV2_MC_ScaleFactor_AK8PFPuppi"}
-};
 
 // Full Type-1 PuppiMET rebuild from RawPuppiMET over the merged AK4 list (Jet + CorrT1METJet)
 // with muon subtraction, per the JERC recipe. Writes met_pt / met_phi (nominal) and, on MC with
 // systematics enabled, met_pt_<sfx> / met_phi_<sfx> for each JES variation. Must run AFTER
 // applyJetEnergyCorrections / applyJetEnergyResolution / applyJESVariations (it consumes
-// Jet_jerFactor and the _Jet_shift_<sfx> columns and re-evaluates the JEC compound) and after
+// Jet_jerFactor and the _Jet_var_<sfx> columns and re-evaluates the JEC compound) and after
 // _Jet_rawpt = (1-Jet_rawFactor)*Jet_pt has been defined on the pristine NanoAOD jets.
 RNode applyType1MET(RNode df, bool isData);
 
@@ -358,52 +95,54 @@ RNode applyJetEnergyCorrections(const std::unordered_map<std::string, correction
                                 const std::unordered_map<std::string, std::string>& jec_suffix_map,
                                 RNode df, bool isData);
 
-// JES uncertainty — per-source, suffixed-branch output. Must run after the nominal
-// applyJetEnergyCorrections / applyFatJetEnergyCorrections so the shift is applied on top
-// of the corrected baseline. Each call writes one set of suffixed columns; the driver
-// applyJESVariations loops over the 11 Regrouped V2 sources × {Up, Dn}.
+// JES uncertainty driver — per-source, suffixed-branch output, official JERC ordering:
+// the shift (1 ± u) is applied to the JEC (PRE-smearing) pt, and JER is re-evaluated on
+// the shifted pt with the same event seed as the nominal smearing. Must run after the
+// nominal applyJet/FatJetEnergyCorrections + apply*EnergyResolution (it consumes their
+// pre-smear snapshot columns). Emits all 11 Regrouped V2 sources × {Up, Dn} = 22
+// variations on AK4 + AK8, correlated between the two algorithms (same sources/tags).
 //
-// AK4 helper writes Jet_pt_<suffix>, Jet_mass_<suffix>, met_pt_<suffix>, met_phi_<suffix>
-// (Type-I MET propagated). AK8 helper writes FatJet_pt_<suffix>, FatJet_mass_<suffix>
-// (NOT FatJet_msoftdrop — that has its own JEC recipe) and does NOT propagate to MET
-// because Type-I MET is built from AK4 only.
+// Writes Jet_pt_<suffix>, Jet_mass_<suffix> and the per-jet full variation factor
+// _Jet_var_<suffix> (consumed by applyType1MET for the per-variation MET), plus
+// FatJet_pt_<suffix>, FatJet_mass_<suffix> (NOT FatJet_msoftdrop — that has its own JEC
+// recipe; no MET propagation from AK8 because Type-I MET is built from AK4 only).
 //
 // <suffix> = "jes" + column_label + direction, e.g. "jesAbsoluteUp", "jesAbsoluteYearDn".
-RNode defineAK4JESVariation(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
-                            const std::unordered_map<std::string, std::string>& jec_prefix_map,
-                            const std::unordered_map<std::string, std::string>& jec_suffix_map,
-                            const std::unordered_map<std::string, std::string>& year_token_map,
-                            RNode df, const std::string& column_label, const std::string& base_source,
-                            bool yearDecorrelated, const std::string& direction);
-
-RNode defineFatJetJESVariation(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
-                               const std::unordered_map<std::string, std::string>& jec_prefix_map,
-                               const std::unordered_map<std::string, std::string>& jec_suffix_map,
-                               const std::unordered_map<std::string, std::string>& year_token_map,
-                               RNode df, const std::string& column_label, const std::string& base_source,
-                               bool yearDecorrelated, const std::string& direction);
-
-// Driver: emits all 11 Regrouped V2 sources × {Up, Dn} = 22 variations on AK4 + AK8.
 RNode applyJESVariations(RNode df);
 
 // When called with false before any analysis, disables all JES/JER variation branches
-// (jesVariationSuffixes() returns empty, applyJESVariations becomes a no-op). Use
+// (the suffix accessors below return empty, applyJESVariations becomes a no-op). Use
 // --no_systs to activate nominal-only mode.
 void setStoreSysts(bool v);
 
-// Public accessor for the 22 variation suffixes (e.g. "jesAbsoluteUp",
-// "jesRelativeSampleYearDn"). Returns empty when setStoreSysts(false) has been called.
+// Public accessors for the variation suffixes. All return empty when
+// setStoreSysts(false) has been called.
+//   jesVariationSuffixes:       the 22 JES suffixes ("jesAbsoluteUp", ..., "jesRelativeSampleYearDn")
+//   jerVariationSuffixes:       {"jerUp", "jerDn"}
+//   kinematicVariationSuffixes: JES + JER combined — the full list of suffixes for which
+//                               <collection>_pt_<sfx>/_mass_<sfx> (+ met_pt_<sfx>) may exist.
+//                               Consumers building per-variation selections should loop over
+//                               this and check column presence (variations are produced on MC
+//                               only today, and only by the correction steps that ran).
 std::vector<std::string> jesVariationSuffixes();
+std::vector<std::string> jerVariationSuffixes();
+std::vector<std::string> kinematicVariationSuffixes();
 
-// JER smearing (MC only). Propagates to met_pt / met_phi as well.
+// JER hybrid smearing (MC only). Defines Jet_jerFactor and redefines Jet_pt/Jet_mass to the
+// nominal-smeared values. With storeVariations, also writes the ±1σ SF variation branches
+// Jet_jerFactor_jerUp/Dn and Jet_pt/mass_jerUp/Dn (from the same pre-smear baseline, same
+// stochastic seed → fully correlated with the nominal). The ±1σ SF is ScaleFactor ±
+// SFUncertainty (split-tag format; the pinned ScaleFactor has no `systematic` axis).
+// All factors are consumed by applyType1MET for the MET rebuild.
 RNode applyJetEnergyResolution(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
                                const std::unordered_map<std::string, correction::CorrectionSet>& cset_jer_smear,
                                const std::unordered_map<std::string, std::string>& jer_res_map,
                                const std::unordered_map<std::string, std::string>& jer_sf_map,
-                               RNode df, std::string variation);
+                               const std::unordered_map<std::string, std::string>& jer_unc_map,
+                               RNode df, bool storeVariations);
 
 // AK8 (FatJet_*) variants — same recipe as AK4 but reading FatJet_* / GenJetAK8_* branches
-// and the AK8PFPuppi compound from fatJet_jerc.json.gz. 
+// and the AK8PFPuppi compound from fatJet_jerc.json.gz.
 RNode applyFatJetEnergyCorrections(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
                                    const std::unordered_map<std::string, std::string>& jec_prefix_map,
                                    const std::unordered_map<std::string, std::string>& jec_suffix_map,
@@ -413,38 +152,14 @@ RNode applyFatJetEnergyResolution(const std::unordered_map<std::string, correcti
                                   const std::unordered_map<std::string, correction::CorrectionSet>& cset_jer_smear,
                                   const std::unordered_map<std::string, std::string>& jer_res_map,
                                   const std::unordered_map<std::string, std::string>& jer_sf_map,
-                                  RNode df, std::string variation);
+                                  const std::unordered_map<std::string, std::string>& jer_unc_map,
+                                  RNode df, bool storeVariations);
 
 /*
 ############################################
 JET VETO MAPS
 ############################################
 */
-// Run 2 recommendations: https://cms-jerc.web.cern.ch/Recommendations/#run-2_1
-const std::unordered_map<std::string, correction::CorrectionSet> jetVetoMaps = {
-    {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016preVFP-UL-NanoAODv9/latest/jetvetomaps.json.gz")},
-    {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2016postVFP-UL-NanoAODv9/latest/jetvetomaps.json.gz")},
-    {"2017", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2017-UL-NanoAODv9/latest/jetvetomaps.json.gz")},
-    {"2018", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run2-2018-UL-NanoAODv9/latest/jetvetomaps.json.gz")},
-    {"2022Re-recoBCD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/latest/jetvetomaps.json.gz")},
-    {"2022Re-recoE+PromptFG", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22EFGSep23-Summer22EE-NanoAODv12/latest/jetvetomaps.json.gz")},
-    {"2023PromptC", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23CSep23-Summer23-NanoAODv12/latest/jetvetomaps.json.gz")},
-    {"2023PromptD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23DSep23-Summer23BPix-NanoAODv12/latest/jetvetomaps.json.gz")},
-    {"2024Prompt", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/latest/jetvetomaps.json.gz")}
-};
-
-const std::unordered_map<std::string, std::string> jetVetoMap_names = {
-    {"2016preVFP", "Summer19UL16_V1"},
-    {"2016postVFP", "Summer19UL16_V1"},
-    {"2017", "Summer19UL17_V1"},
-    {"2018", "Summer19UL18_V1"},
-    {"2022Re-recoBCD", "Summer22_23Sep2023_RunCD_V1"},
-    {"2022Re-recoE+PromptFG", "Summer22EE_23Sep2023_RunEFG_V1"},
-    {"2023PromptC", "Summer23Prompt23_RunC_V1"},
-    {"2023PromptD", "Summer23BPixPrompt23_RunD_V1"},
-    {"2024Prompt", "Summer24Prompt24_RunBCDEFGHI_V1"}
-};
-
 RNode applyJetVetoMaps(RNode df);
 
 /*
@@ -452,18 +167,6 @@ RNode applyJetVetoMaps(RNode df);
 ELECTRON SCALE AND SMEARING CORRECTIONS
 ############################################
 */
-const std::unordered_map<std::string, correction::CorrectionSet> electronSSCorrections = {
-    {"2016preVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run2-2016preVFP-UL-NanoAODv15/latest/electronSS_EtDependent.json.gz")},
-    {"2016postVFP", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run2-2016postVFP-UL-NanoAODv15/latest/electronSS_EtDependent.json.gz")},
-    {"2017", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run2-2017-UL-NanoAODv15/latest/electronSS_EtDependent.json.gz")},
-    {"2018", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run2-2018-UL-NanoAODv15/latest/electronSS_EtDependent.json.gz")},
-    {"2022Re-recoBCD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run3-22CDSep23-Summer22-NanoAODv12/latest/electronSS_EtDependent.json.gz")},
-    {"2022Re-recoE+PromptFG", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run3-22EFGSep23-Summer22EE-NanoAODv12/latest/electronSS_EtDependent.json.gz")},
-    {"2023PromptC", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run3-23CSep23-Summer23-NanoAODv12/latest/electronSS_EtDependent.json.gz")},
-    {"2023PromptD", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run3-23DSep23-Summer23BPix-NanoAODv12/latest/electronSS_EtDependent.json.gz")},
-    {"2024Prompt", *CorrectionSet::from_file("/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/latest/electronSS_EtDependent.json.gz")}
-};
-
 RNode applyElectronScaleAndSmearing(RNode df, bool isData);
 
 /*

--- a/preselection/src/corrections.h
+++ b/preselection/src/corrections.h
@@ -6,6 +6,8 @@
 #include <unordered_map>
 #include <string>
 #include <iostream>
+#include <vector>
+#include <array>
 
 #include "ROOT/RDataFrame.hxx"
 #include "ROOT/RDFHelpers.hxx"
@@ -234,6 +236,21 @@ const std::unordered_map<std::string, std::string> fatJetEnergyCorrections_JEC_s
     {"2024Prompt", "AK8PFPuppi"}
 };
 
+// Year token embedded in the year-decorrelated Regrouped JEC source names
+// (e.g. "Summer20UL18NanoV15_V1_MC_Regrouped_Absolute_2018_AK4PFPuppi"). Confirmed
+// against jet_jerc.json.gz / fatJet_jerc.json.gz for every campaign on 2026-05-14.
+const std::unordered_map<std::string, std::string> jetEnergyCorrections_yearToken = {
+    {"2016preVFP", "2016APV"},
+    {"2016postVFP", "2016"},
+    {"2017", "2017"},
+    {"2018", "2018"},
+    {"2022Re-recoBCD", "2022"},
+    {"2022Re-recoE+PromptFG", "2022EE"},
+    {"2023PromptC", "2023"},
+    {"2023PromptD", "2023BPix"},
+    {"2024Prompt", "2024"}
+};
+
 // JER tag names 
 // FIXME: 2024 re-uses the 2023BPix JR until a dedicated 2024 release lands
 const std::unordered_map<std::string, std::string> jetEnergyResolution_JER_res_name = {
@@ -293,12 +310,38 @@ RNode applyJetEnergyCorrections(const std::unordered_map<std::string, correction
                                 const std::unordered_map<std::string, std::string>& jec_suffix_map,
                                 RNode df, bool isData);
 
-// JES uncertainty (nominal/up/down). Must run after applyJetEnergyCorrections so the
-// per-source uncertainty is applied on top of the corrected baseline.
-RNode applyJetEnergyScaleVariation(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
-                                   const std::unordered_map<std::string, std::string>& jec_prefix_map,
-                                   const std::unordered_map<std::string, std::string>& jec_suffix_map,
-                                   RNode df, std::string JEC_source, std::string variation);
+// JES uncertainty — per-source, suffixed-branch output. Must run after the nominal
+// applyJetEnergyCorrections / applyFatJetEnergyCorrections so the shift is applied on top
+// of the corrected baseline. Each call writes one set of suffixed columns; the driver
+// applyJESVariations loops over the 11 Regrouped V2 sources × {Up, Dn}.
+//
+// AK4 helper writes Jet_pt_<suffix>, Jet_mass_<suffix>, met_pt_<suffix>, met_phi_<suffix>
+// (Type-I MET propagated). AK8 helper writes FatJet_pt_<suffix>, FatJet_mass_<suffix>
+// (NOT FatJet_msoftdrop — that has its own JEC recipe) and does NOT propagate to MET
+// because Type-I MET is built from AK4 only.
+//
+// <suffix> = "jes" + column_label + direction, e.g. "jesAbsoluteUp", "jesAbsoluteYearDn".
+RNode defineAK4JESVariation(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
+                            const std::unordered_map<std::string, std::string>& jec_prefix_map,
+                            const std::unordered_map<std::string, std::string>& jec_suffix_map,
+                            const std::unordered_map<std::string, std::string>& year_token_map,
+                            RNode df, const std::string& column_label, const std::string& base_source,
+                            bool yearDecorrelated, const std::string& direction);
+
+RNode defineFatJetJESVariation(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,
+                               const std::unordered_map<std::string, std::string>& jec_prefix_map,
+                               const std::unordered_map<std::string, std::string>& jec_suffix_map,
+                               const std::unordered_map<std::string, std::string>& year_token_map,
+                               RNode df, const std::string& column_label, const std::string& base_source,
+                               bool yearDecorrelated, const std::string& direction);
+
+// Driver: emits all 11 Regrouped V2 sources × {Up, Dn} = 22 variations on AK4 + AK8.
+RNode applyJESVariations(RNode df);
+
+// Public accessor for the 22 variation suffixes (e.g. "jesAbsoluteUp",
+// "jesRelativeSampleYearDn"). Single source of truth shared with selections.cpp,
+// which uses it to emit per-variation good-jet masks (Jet_isGood_<sfx>).
+std::vector<std::string> jesVariationSuffixes();
 
 // JER smearing (MC only). Propagates to met_pt / met_phi as well.
 RNode applyJetEnergyResolution(const std::unordered_map<std::string, correction::CorrectionSet>& cset_jerc,

--- a/preselection/src/main.cpp
+++ b/preselection/src/main.cpp
@@ -32,6 +32,7 @@ struct MyArgs : public argparse::Args {
     bool &runSPANetInference     = flag("spanet_infer", "Run SPANet inference").set_default(false);
     bool &storeHLT = flag("store_hlt", "Store HLT trigger branches in output").set_default(false);
     bool &cutflow = flag("cutflow", "Print cutflow").set_default(false);
+    bool &no_systs = flag("no_systs", "Skip all JES/JER variation branches (nominal only)").set_default(false);
 };
 
 RNode runAnalysis(RNode df, std::string ana, std::string run_number, bool isSignal, SPANet::SPANetInference *spanet_inference, SPANetRun2::SPANetInference *spanet_inference_run2, bool runSPANetInference = false, bool makeSpanetTrainingdata = false)
@@ -63,6 +64,8 @@ int main(int argc, char** argv) {
     auto args = argparse::parse<MyArgs>(argc, argv);
     std::string input_spec = args.spec;
     std::string output_file = args.name;
+
+    setStoreSysts(!args.no_systs);
 
     if (args.nthread > 64) {
         std::cerr << "Error: nthread cannot exceed 64 (requested: " << args.nthread << ")" << std::endl;

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -202,7 +202,7 @@ RNode AK4JetsSelection(RNode df_, bool cleanAgainstFJ, std::string affix)
                                     "(Jet_pt > 50 && abs(Jet_eta) > 2.5 && abs(Jet_eta) < 3.0))) ||"
                                     "(isRun2 && Jet_pt > 20 && abs(Jet_eta) < 5.0)) &&  "
                                     "(Jet_jetId >= 2)"); // NanoAOD jetID convention https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookNanoAOD#Jets
-                                                        // should still work for current skimmer, which sets jetId==3 : "pass tight ID, fail tightLepVeto", jetId==7 : "pass tight and tightLepVeto ID"
+                                                        // should still work for skims < v28, which set jetId==3 : "pass tight ID, fail tightLepVeto", jetId==7 : "pass tight and tightLepVeto ID"
 
     df = df.Filter("(isRun2) || (isRun3 && !Any(Jet_vetoMap))");
     df = df.Redefine("_good_ak4jets", "_good_ak4jets && !Jet_vetoMap");
@@ -210,21 +210,21 @@ RNode AK4JetsSelection(RNode df_, bool cleanAgainstFJ, std::string affix)
     df = applyObjectMaskNewAffix(df, "_good_ak4jets", "Jet", affix);
     df = df.Define("ht_" + affix, "Sum(" + affix + "_pt)");
 
-    // Per-variation good-jet masks at the all-jet level (capital). Same selection logic
-    // as nominal but with Jet_pt swapped for the JES-shifted column. Defined once,
-    // alongside the primary FJ-cleaned "jet" collection. NOTE: these use
-    // ak4GoodJetSelectionExpr, which does NOT include the fat-jet cleaning cut applied to
-    // the nominal "jet" collection above -- variation masks preserve the pre-refactor JES
-    // definition (no FJ cleaning). Stored on the snapshot so downstream coffea can
-    // construct per-variation jet collections from the single-copy capital Jet_*
-    // attributes (eta, phi, btag, ...) plus per-variation Jet_pt_<sfx> / Jet_mass_<sfx> +
-    // Jet_isGood_<sfx>. Defined AFTER applyObjectMaskNewAffix so they don't get
-    // nominal-masked into lowercase aliases.
+    // Nominal + per-variation good-jet masks stored at the NanoAOD (capital-collection) level.
+    // Defined once, alongside the primary FJ-cleaned "jet" collection, and AFTER
+    // applyObjectMaskNewAffix so they are not aliased into lowercase jet_isGood columns.
+    // Downstream coffea uses Jet_isGood (nominal) and Jet_isGood_<sfx> (variations)
+    // uniformly to construct jet collections from the shared Jet_* arrays.
+    //
+    // NOTE: the per-variation masks use ak4GoodJetSelectionExpr, which does NOT include
+    // the fat-jet cleaning cut applied to the nominal "jet" mask (_good_ak4jets) above --
+    // variation masks preserve the pre-refactor JES definition (no FJ cleaning).
     //
     // njet_<sfx> = Sum(Jet_isGood_<sfx>) parallels the nominal `njet` (defined inside
     // applyObjectMaskNewAffix) and feeds the per-variation channel-pass flags built in
     // runPreselection.
     if (affix == "jet") {
+        df = df.Define("Jet_isGood", "_good_ak4jets");
         for (const auto& sfx : jesVariationSuffixes()) {
             df = df.Define("Jet_isGood_" + sfx,
                            ak4GoodJetSelectionExpr("Jet_pt_" + sfx) + " && !Jet_vetoMap");
@@ -248,24 +248,21 @@ RNode AK4JetProperties(RNode df_)
 RNode AK8JetsSelection(RNode df_)
 {
     auto df = df_.Define("_dR_ak8_lep", VVdR, {"FatJet_eta", "FatJet_phi", "lepton_eta", "lepton_phi"})
-                  .Define("_good_ak8jets", ak8GoodJetSelectionExpr("FatJet_pt"))
-                  .Define("nFatJets", "Sum(_good_ak8jets)");
+                  .Define("_good_ak8jets", ak8GoodJetSelectionExpr("FatJet_pt"));
 
     df = applyObjectMaskNewAffix(df, "_good_ak8jets", "FatJet", "fatjet");
     df = df.Define("ht_fatjets", "Sum(fatjet_pt)");
 
+    // Nominal good-fat-jet mask and count — defined AFTER applyObjectMaskNewAffix so they
+    // are not aliased into fatjet_isGood. FatJet_isGood (nominal) mirrors the per-variation
+    // FatJet_isGood_<sfx> branches; coffea uses them uniformly.
+    df = df.Define("FatJet_isGood", "_good_ak8jets");
+    df = df.Define("nFatJets",      "Sum(FatJet_isGood)");
+
     // Per-variation good-fatjet masks. JES affects FatJet_pt only; FatJet_msoftdrop is
-    // unchanged (its own JEC recipe lives in [[softdrop_mass_jec_recipe]]). Defined AFTER
-    // applyObjectMaskNewAffix for the same reason as the AK4 case.
-    //
-    // Two parallel count names per variation, mirroring the nominal pair:
-    //   nFatJets (defined above)  ↔  nFatJets_<sfx>   — used by 0lep / 2lep channel filters
-    //   nfatjet  (from applyObjectMaskNewAffix) ↔ nfatjet_<sfx> — used by 1lep channels
-    // Both equal Sum(FatJet_isGood_<sfx>). Defined together to keep the per-variation
-    // pass-flag expressions parallel to the nominal channel-filter expressions.
+    // unchanged. Defined AFTER applyObjectMaskNewAffix for the same reason as the AK4 case.
     for (const auto& sfx : jesVariationSuffixes()) {
         df = df.Define("FatJet_isGood_" + sfx, ak8GoodJetSelectionExpr("FatJet_pt_" + sfx));
-        df = df.Define("nfatjet_"  + sfx, "Sum(FatJet_isGood_" + sfx + ")");
         df = df.Define("nFatJets_" + sfx, "Sum(FatJet_isGood_" + sfx + ")");
     }
     return df;
@@ -362,9 +359,12 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
         });
         df = df.Filter(orPassExpr("0lep_1FJ"), "C2: 0lep_1FJ");
 
-        df = df.Define("met_significance", "PuppiMET_significance")
+        df = df.DefaultValueFor("Pileup_nTrueInt", (float)-1.f)
+                .Define("met_significance", "PuppiMET_significance")
                 .Define("met_uncorrPt", "PuppiMET_pt")
-                .Define("met_uncorrPhi", "PuppiMET_phi");
+                .Define("met_uncorrPhi", "PuppiMET_phi")
+                .Define("pileup_nTrueInt", "Pileup_nTrueInt")
+                .Define("pv_npvsGood", "PV_npvsGood");
 
     }
 
@@ -398,6 +398,13 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
             return "((nMuon_Loose == 0) && (nElectron_Loose == 0)) && (" + n + " == 2)";
         });
         df = df.Filter(orPassExpr("0lep_2FJ"), "C2: 0lep_2FJ");
+
+        df = df.DefaultValueFor("Pileup_nTrueInt", (float)-1.f)
+                .Define("met_significance", "PuppiMET_significance")
+                .Define("met_uncorrPt", "PuppiMET_pt")
+                .Define("met_uncorrPhi", "PuppiMET_phi")
+                .Define("pileup_nTrueInt", "Pileup_nTrueInt")
+                .Define("pv_npvsGood", "PV_npvsGood");
     }
 
     // 0lep_2FJ_met
@@ -450,8 +457,8 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
         Cutflow::Add(df, "C2: 1-lepton selection");
 
         df = definePerVariationPassFlags(df, "1lep_1FJ", [](const std::string& sfx){
-            const std::string fj = sfx.empty() ? "nfatjet" : "nfatjet_" + sfx;
-            const std::string j  = sfx.empty() ? "njet"    : "njet_"    + sfx;
+            const std::string fj = sfx.empty() ? "nFatJets" : "nFatJets_" + sfx;
+            const std::string j  = sfx.empty() ? "njet"     : "njet_"     + sfx;
             return "(" + fj + " == 1) && (" + j + " >= 4)";
         });
         df = df.Filter(orPassExpr("1lep_1FJ"), "C3: jet selection (any variation)");
@@ -476,8 +483,8 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
         Cutflow::Add(df, "C2: 1-lepton selection");
 
         df = definePerVariationPassFlags(df, "1lep_2FJ", [](const std::string& sfx){
-            const std::string fj = sfx.empty() ? "nfatjet" : "nfatjet_" + sfx;
-            const std::string j  = sfx.empty() ? "njet"    : "njet_"    + sfx;
+            const std::string fj = sfx.empty() ? "nFatJets" : "nFatJets_" + sfx;
+            const std::string j  = sfx.empty() ? "njet"     : "njet_"     + sfx;
             return "(" + fj + " >= 2) && (" + j + " >= 2)";
         });
         df = df.Filter(orPassExpr("1lep_2FJ"), "C3: jet selection (any variation)");

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -153,7 +153,8 @@ RNode AK4JetsSelection(RNode df_, bool cleanAgainstFJ, std::string affix)
                                     "((isRun3 && ((Jet_pt > 20 && (abs(Jet_eta) <= 2.5 || abs(Jet_eta) >= 3.0) && abs(Jet_eta) < 5.0) || "
                                     "(Jet_pt > 50 && abs(Jet_eta) > 2.5 && abs(Jet_eta) < 3.0))) ||"
                                     "(isRun2 && Jet_pt > 20 && abs(Jet_eta) < 5.0)) &&  "
-                                    "((is2016 && Jet_jetId >= 1) || (!is2016 && Jet_jetId >= 2))");
+                                    "(Jet_jetId >= 2)"); // NanoAOD jetID convention https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookNanoAOD#Jets
+                                                        // should still work for current skimmer, which sets jetId==3 : "pass tight ID, fail tightLepVeto", jetId==7 : "pass tight and tightLepVeto ID"
 
     df = df.Filter("(isRun2) || (isRun3 && !Any(Jet_vetoMap))");
     df = df.Redefine("_good_ak4jets", "_good_ak4jets && !Jet_vetoMap");

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -252,6 +252,19 @@ RNode AK4JetsSelection(RNode df_, bool cleanAgainstFJ, std::string affix)
             df = df.Define("njet_" + sfx, "Sum(Jet_isGood_" + sfx + ")");
         }
     }
+    // Nominal + per-variation masks for the non-FJ-cleaned collection, used by
+    // VBSTagging in channels that tag on "jetNoFJClean" (1lep_2FJ). No FJ cleaning to
+    // re-evaluate, so the mask is just the pt-varied good-jet expression + veto map.
+    // The Jet_ prefix means the masks are written to the output (snapshot keeps all
+    // Jet_* columns), mirroring Jet_isGood / Jet_isGood_<sfx> for the cleaned set.
+    else if (affix == "jetNoFJClean") {
+        df = df.Define("Jet_isGoodNoFJClean", "_good_ak4jets");
+        for (const auto& sfx : activeKinVariations(df)) {
+            df = df.Define("Jet_isGoodNoFJClean_" + sfx,
+                           ak4GoodJetSelectionExpr("Jet_pt_" + sfx) + " && !Jet_vetoMap");
+            df = df.Define("njetNoFJClean_" + sfx, "Sum(Jet_isGoodNoFJClean_" + sfx + ")");
+        }
+    }
     return df;
 }
 
@@ -290,25 +303,51 @@ RNode AK8JetsSelection(RNode df_)
 }
 
 // Perform VBS jet tagging via VBSBDTInfer and compute VBS pair kinematics
-// Note this requires at least 2 jets (i.e., applies a njet >= 2 filter)
+// The nominal or a variation with < 2 taggable jets gets sentinel values instead (indices -1, score/kinematics -999).
 RNode VBSTagging(RNode df_, std::string jetCollectionName = "jet")
 {
-    return df_.Filter("n" + jetCollectionName + " >= 2", "At-least 2 overlap-removed (against FJ) jets")
+    // All-jet-level mask stem for the tagging collection. The per-variation masks are
+    // defined in AK4JetsSelection for both stems.
+    const bool fjCleaned = (jetCollectionName == "jet");
+    const std::string maskStem = fjCleaned ? "Jet_isGood" : "Jet_isGoodNoFJClean";
+
+    // Continue to store the full four vector of the two VBS candidates when running 
+    // on nominal for backwards compatibility.
+    auto df = df_
         .Define("_vbs_candidate_jet_pairs", VBSBDTInfer, {jetCollectionName + "_pt", jetCollectionName + "_eta", jetCollectionName + "_phi", jetCollectionName + "_mass", "isRun2"})
-        .Define("vbs_jet1_idx", "static_cast<int>(_vbs_candidate_jet_pairs[0])")
+        .Define("vbs_jet1_idx", "static_cast<int>(_vbs_candidate_jet_pairs[0])") // indices in the "good jet" collection
         .Define("vbs_jet2_idx", "static_cast<int>(_vbs_candidate_jet_pairs[1])")
-        .Define("vbs_score", "_vbs_candidate_jet_pairs[2]")
-        .Define("vbs_jet1_pt",   jetCollectionName + "_pt[vbs_jet1_idx]")
-        .Define("vbs_jet1_eta",  jetCollectionName + "_eta[vbs_jet1_idx]")
-        .Define("vbs_jet1_phi",  jetCollectionName + "_phi[vbs_jet1_idx]")
-        .Define("vbs_jet1_mass", jetCollectionName + "_mass[vbs_jet1_idx]")
-        .Define("vbs_jet2_pt",   jetCollectionName + "_pt[vbs_jet2_idx]")
-        .Define("vbs_jet2_eta",  jetCollectionName + "_eta[vbs_jet2_idx]")
-        .Define("vbs_jet2_phi",  jetCollectionName + "_phi[vbs_jet2_idx]")
-        .Define("vbs_jet2_mass", jetCollectionName + "_mass[vbs_jet2_idx]")
-        .Define("vbs_mjj",    "(ROOT::Math::PtEtaPhiMVector(vbs_jet1_pt, vbs_jet1_eta, vbs_jet1_phi, vbs_jet1_mass) + "
-                              "ROOT::Math::PtEtaPhiMVector(vbs_jet2_pt, vbs_jet2_eta, vbs_jet2_phi, vbs_jet2_mass)).M()")
-        .Define("vbs_detajj", "abs(vbs_jet1_eta - vbs_jet2_eta)");
+        .Define("vbs_score", "vbs_jet1_idx >= 0 ? _vbs_candidate_jet_pairs[2] : -999.f")
+        .Define("vbs_jet1_pt",   "vbs_jet1_idx >= 0 ? " + jetCollectionName + "_pt[vbs_jet1_idx]   : -999.f")
+        .Define("vbs_jet1_eta",  "vbs_jet1_idx >= 0 ? " + jetCollectionName + "_eta[vbs_jet1_idx]  : -999.f")
+        .Define("vbs_jet1_phi",  "vbs_jet1_idx >= 0 ? " + jetCollectionName + "_phi[vbs_jet1_idx]  : -999.f")
+        .Define("vbs_jet1_mass", "vbs_jet1_idx >= 0 ? " + jetCollectionName + "_mass[vbs_jet1_idx] : -999.f")
+        .Define("vbs_jet2_pt",   "vbs_jet2_idx >= 0 ? " + jetCollectionName + "_pt[vbs_jet2_idx]   : -999.f")
+        .Define("vbs_jet2_eta",  "vbs_jet2_idx >= 0 ? " + jetCollectionName + "_eta[vbs_jet2_idx]  : -999.f")
+        .Define("vbs_jet2_phi",  "vbs_jet2_idx >= 0 ? " + jetCollectionName + "_phi[vbs_jet2_idx]  : -999.f")
+        .Define("vbs_jet2_mass", "vbs_jet2_idx >= 0 ? " + jetCollectionName + "_mass[vbs_jet2_idx] : -999.f")
+        .Define("vbs_mjj",    "vbs_jet1_idx >= 0 ? (ROOT::Math::PtEtaPhiMVector(vbs_jet1_pt, vbs_jet1_eta, vbs_jet1_phi, vbs_jet1_mass) + "
+                              "ROOT::Math::PtEtaPhiMVector(vbs_jet2_pt, vbs_jet2_eta, vbs_jet2_phi, vbs_jet2_mass)).M() : -999.")
+        .Define("vbs_detajj", "vbs_jet1_idx >= 0 ? abs(vbs_jet1_eta - vbs_jet2_eta) : -999.");
+
+    // Nominal VBS-jet indices in the all-jet (NanoAOD Jet_*) collection, corresponding 
+    // to the same physical jets as vbs_jet1/2_idx; stored so downstream
+    // handles nominal and variations uniformly via Jet_*[vbs_jet*_Jetidx*].
+    df = df.Define("vbs_jet1_Jetidx", "vbs_jet1_idx >= 0 ? static_cast<int>(ROOT::VecOps::Nonzero(" + maskStem + ")[vbs_jet1_idx]) : -1")
+           .Define("vbs_jet2_Jetidx", "vbs_jet2_idx >= 0 ? static_cast<int>(ROOT::VecOps::Nonzero(" + maskStem + ")[vbs_jet2_idx]) : -1");
+
+    // Per-variation VBS tagging: re-run the BDT on the variation's good-jet set with its
+    // varied pt/mass (eta/phi are JEC-invariant). Only the two all-jet-frame indices and
+    // the score are stored per variation — downstream can rebuild the kinematics from
+    // Jet_*[vbs_jet*_Jetidx*], keeping the branch count small.
+    for (const auto& sfx : activeKinVariations(df)) {
+        df = df.Define("_vbs_pair_" + sfx, VBSBDTInferMasked,
+                       {maskStem + "_" + sfx, "Jet_pt_" + sfx, "Jet_eta", "Jet_phi", "Jet_mass_" + sfx, "isRun2"});
+        df = df.Define("vbs_jet1_Jetidx_" + sfx, "static_cast<int>(_vbs_pair_" + sfx + "[0])");
+        df = df.Define("vbs_jet2_Jetidx_" + sfx, "static_cast<int>(_vbs_pair_" + sfx + "[1])");
+        df = df.Define("vbs_score_" + sfx, "_vbs_pair_" + sfx + "[2]");
+    }
+    return df;
 }
 
 

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -22,6 +22,31 @@ inline std::string ak8GoodJetSelectionExpr(const std::string& ptCol) {
            "FatJet_msoftdrop > 40 && "
            "FatJet_jetId > 0";
 }
+
+// Per-variation channel-pass-flag generation. Each channel filter that depends on a
+// jet-multiplicity cut emits a boolean per event for each variation v ∈ {nom} ∪
+// jesVariationSuffixes() — passes_<channel>_<v> — then the channel filter is OR over
+// those flags. This keeps events that pass the channel under ANY variation, which is
+// the only way a single output file can carry per-variation histograms downstream.
+//
+// `expr_for(sfx)` returns the full pass condition for variation `sfx`. sfx == "" means
+// nominal; the lambda should return the nominal condition string in that case.
+template <typename F>
+RNode definePerVariationPassFlags(RNode df, const std::string& channel, F&& expr_for) {
+    df = df.Define("passes_" + channel + "_nom", expr_for(std::string{}));
+    for (const auto& sfx : jesVariationSuffixes()) {
+        df = df.Define("passes_" + channel + "_" + sfx, expr_for(sfx));
+    }
+    return df;
+}
+
+inline std::string orPassExpr(const std::string& channel) {
+    std::string out = "passes_" + channel + "_nom";
+    for (const auto& sfx : jesVariationSuffixes()) {
+        out += " || passes_" + channel + "_" + sfx;
+    }
+    return out;
+}
 } // anonymous namespace
 
 // MET filters
@@ -195,10 +220,15 @@ RNode AK4JetsSelection(RNode df_, bool cleanAgainstFJ, std::string affix)
     // attributes (eta, phi, btag, ...) plus per-variation Jet_pt_<sfx> / Jet_mass_<sfx> +
     // Jet_isGood_<sfx>. Defined AFTER applyObjectMaskNewAffix so they don't get
     // nominal-masked into lowercase aliases.
+    //
+    // njet_<sfx> = Sum(Jet_isGood_<sfx>) parallels the nominal `njet` (defined inside
+    // applyObjectMaskNewAffix) and feeds the per-variation channel-pass flags built in
+    // runPreselection.
     if (affix == "jet") {
         for (const auto& sfx : jesVariationSuffixes()) {
             df = df.Define("Jet_isGood_" + sfx,
                            ak4GoodJetSelectionExpr("Jet_pt_" + sfx) + " && !Jet_vetoMap");
+            df = df.Define("njet_" + sfx, "Sum(Jet_isGood_" + sfx + ")");
         }
     }
     return df;
@@ -227,8 +257,16 @@ RNode AK8JetsSelection(RNode df_)
     // Per-variation good-fatjet masks. JES affects FatJet_pt only; FatJet_msoftdrop is
     // unchanged (its own JEC recipe lives in [[softdrop_mass_jec_recipe]]). Defined AFTER
     // applyObjectMaskNewAffix for the same reason as the AK4 case.
+    //
+    // Two parallel count names per variation, mirroring the nominal pair:
+    //   nFatJets (defined above)  ↔  nFatJets_<sfx>   — used by 0lep / 2lep channel filters
+    //   nfatjet  (from applyObjectMaskNewAffix) ↔ nfatjet_<sfx> — used by 1lep channels
+    // Both equal Sum(FatJet_isGood_<sfx>). Defined together to keep the per-variation
+    // pass-flag expressions parallel to the nominal channel-filter expressions.
     for (const auto& sfx : jesVariationSuffixes()) {
         df = df.Define("FatJet_isGood_" + sfx, ak8GoodJetSelectionExpr("FatJet_pt_" + sfx));
+        df = df.Define("nfatjet_"  + sfx, "Sum(FatJet_isGood_" + sfx + ")");
+        df = df.Define("nFatJets_" + sfx, "Sum(FatJet_isGood_" + sfx + ")");
     }
     return df;
 }
@@ -298,11 +336,12 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
         df = TriggerSelections(df,trigger_logic_string_0lep0FJ);
         Cutflow::Add(df, "C1: Trigger selection");
 
-        df = df.Filter(
-            "((nMuon_Loose == 0) && (nElectron_Loose == 0)) &&"
-            "(nFatJets == 0)",
-            "C2: 0lep_0FJ"
-        );
+        df = definePerVariationPassFlags(df, "0lep_0FJ", [](const std::string& sfx){
+            const std::string n = sfx.empty() ? "nFatJets" : "nFatJets_" + sfx;
+            return "((nMuon_Loose == 0) && (nElectron_Loose == 0)) && (" + n + " == 0)";
+        });
+        df = df.Filter(orPassExpr("0lep_0FJ"), "C2: 0lep_0FJ");
+
         df = df.Define("met_significance", "PuppiMET_significance")
                 .Define("met_uncorrPt", "PuppiMET_pt")
                 .Define("met_uncorrPhi", "PuppiMET_phi");
@@ -317,11 +356,12 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
         df = TriggerSelections(df,trigger_logic_string_0lep1FJ);
         Cutflow::Add(df, "C1: Trigger selection");
 
-        df = df.Filter(
-            "((nMuon_Loose == 0) && (nElectron_Loose == 0)) &&"
-            "(nFatJets == 1)",
-            "C2: 0lep_1FJ"
-        );
+        df = definePerVariationPassFlags(df, "0lep_1FJ", [](const std::string& sfx){
+            const std::string n = sfx.empty() ? "nFatJets" : "nFatJets_" + sfx;
+            return "((nMuon_Loose == 0) && (nElectron_Loose == 0)) && (" + n + " == 1)";
+        });
+        df = df.Filter(orPassExpr("0lep_1FJ"), "C2: 0lep_1FJ");
+
         df = df.Define("met_significance", "PuppiMET_significance")
                 .Define("met_uncorrPt", "PuppiMET_pt")
                 .Define("met_uncorrPhi", "PuppiMET_phi");
@@ -337,11 +377,11 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
         df = TriggerSelections(df,trigger_logic_string_met);
         Cutflow::Add(df, "C1: Trigger selection");
 
-        df = df.Filter(
-            "((nMuon_Loose == 0) && (nElectron_Loose == 0)) &&"
-            "(nFatJets == 1)",
-            "C2: 0lep_1FJ"
-        );
+        df = definePerVariationPassFlags(df, "0lep_1FJ_met", [](const std::string& sfx){
+            const std::string n = sfx.empty() ? "nFatJets" : "nFatJets_" + sfx;
+            return "((nMuon_Loose == 0) && (nElectron_Loose == 0)) && (" + n + " == 1)";
+        });
+        df = df.Filter(orPassExpr("0lep_1FJ_met"), "C2: 0lep_1FJ");
     }
 
     // 0lep_2FJ
@@ -353,11 +393,11 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
         df = TriggerSelections(df,trigger_logic_string_ht);
         Cutflow::Add(df, "C1: Trigger selection");
 
-        df = df.Filter(
-            "((nMuon_Loose == 0) && (nElectron_Loose == 0)) &&"
-            "(nFatJets == 2)",
-            "C2: 0lep_2FJ"
-        );
+        df = definePerVariationPassFlags(df, "0lep_2FJ", [](const std::string& sfx){
+            const std::string n = sfx.empty() ? "nFatJets" : "nFatJets_" + sfx;
+            return "((nMuon_Loose == 0) && (nElectron_Loose == 0)) && (" + n + " == 2)";
+        });
+        df = df.Filter(orPassExpr("0lep_2FJ"), "C2: 0lep_2FJ");
     }
 
     // 0lep_2FJ_met
@@ -369,11 +409,11 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
         df = TriggerSelections(df,trigger_logic_string_met);
         Cutflow::Add(df, "C1: Trigger selection");
 
-        df = df.Filter(
-            "((nMuon_Loose == 0) && (nElectron_Loose == 0)) &&"
-            "(nFatJets == 2)",
-            "C2: 0lep_2FJ"
-        );
+        df = definePerVariationPassFlags(df, "0lep_2FJ_met", [](const std::string& sfx){
+            const std::string n = sfx.empty() ? "nFatJets" : "nFatJets_" + sfx;
+            return "((nMuon_Loose == 0) && (nElectron_Loose == 0)) && (" + n + " == 2)";
+        });
+        df = df.Filter(orPassExpr("0lep_2FJ_met"), "C2: 0lep_2FJ");
     }
 
     // 0lep_3FJ
@@ -385,14 +425,17 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
         df = TriggerSelections(df,trigger_logic_string_ht);
         Cutflow::Add(df, "C1: Trigger selection");
 
-        df = df.Filter(
-            "((nMuon_Loose == 0) && (nElectron_Loose == 0)) &&"
-            "(nFatJets == 3)",
-            "C2: 0lep_3FJ"
-        );
+        df = definePerVariationPassFlags(df, "0lep_3FJ", [](const std::string& sfx){
+            const std::string n = sfx.empty() ? "nFatJets" : "nFatJets_" + sfx;
+            return "((nMuon_Loose == 0) && (nElectron_Loose == 0)) && (" + n + " == 3)";
+        });
+        df = df.Filter(orPassExpr("0lep_3FJ"), "C2: 0lep_3FJ");
     }
 
-    // 1lep_1FJ
+    // 1lep_1FJ — fatjet + njet cuts must combine inside a single per-variation pass flag,
+    // because OR-ing over two consecutive jet-count filters would mix variations across
+    // different cuts. Cutflow C3 + C4 (separate fatjet/njet steps) collapse into a single
+    // "any-variation jet selection" entry.
     else if (channel == "1lep_1FJ"){
 
         df = VBSTagging(df);
@@ -405,13 +448,16 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
                        "(nMuon_Loose == 0 && nMuon_Tight == 0 && nElectron_Loose == 1 && nElectron_Tight == 1)) && "
                        "(lepton_pt[0] > 40)");
         Cutflow::Add(df, "C2: 1-lepton selection");
-        df = df.Filter("nfatjet == 1");
-        Cutflow::Add(df, "C3: exactly 1 fat jet");
-        df = df.Filter("njet >= 4");
-        Cutflow::Add(df, "C4: at-least 4 jets");
+
+        df = definePerVariationPassFlags(df, "1lep_1FJ", [](const std::string& sfx){
+            const std::string fj = sfx.empty() ? "nfatjet" : "nfatjet_" + sfx;
+            const std::string j  = sfx.empty() ? "njet"    : "njet_"    + sfx;
+            return "(" + fj + " == 1) && (" + j + " >= 4)";
+        });
+        df = df.Filter(orPassExpr("1lep_1FJ"), "C3: jet selection (any variation)");
     }
 
-    // 1lep_2FJ
+    // 1lep_2FJ — same caveat as 1lep_1FJ (C3 + C4 collapsed).
     else if (channel == "1lep_2FJ"){
 
         df = VBSTagging(df, "jetNoFJClean");
@@ -428,9 +474,13 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
                        "(lepton_pt[0] > 40)");
                        
         Cutflow::Add(df, "C2: 1-lepton selection");
-        df = df.Filter("nfatjet >= 2");
-        Cutflow::Add(df, "C3: at-least 2 fat jets");
 
+        df = definePerVariationPassFlags(df, "1lep_2FJ", [](const std::string& sfx){
+            const std::string fj = sfx.empty() ? "nfatjet" : "nfatjet_" + sfx;
+            const std::string j  = sfx.empty() ? "njet"    : "njet_"    + sfx;
+            return "(" + fj + " >= 2) && (" + j + " >= 2)";
+        });
+        df = df.Filter(orPassExpr("1lep_2FJ"), "C3: jet selection (any variation)");
     }
 
     // 2lepSS
@@ -458,11 +508,11 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
         df = TriggerSelections(df,trigger_logic_string_multilep);
         Cutflow::Add(df, "C1: Trigger selection");
 
-        df = df.Filter(
-            "((nMuon_Loose + nElectron_Loose) == 2) &&"
-            "(nFatJets == 1)",
-            "C2: 2lep_1FJ"
-        );
+        df = definePerVariationPassFlags(df, "2lep_1FJ", [](const std::string& sfx){
+            const std::string n = sfx.empty() ? "nFatJets" : "nFatJets_" + sfx;
+            return "((nMuon_Loose + nElectron_Loose) == 2) && (" + n + " == 1)";
+        });
+        df = df.Filter(orPassExpr("2lep_1FJ"), "C2: 2lep_1FJ");
     }
 
     // 2lep_2FJ
@@ -474,11 +524,11 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
         df = TriggerSelections(df,trigger_logic_string_multilep);
         Cutflow::Add(df, "C1: Trigger selection");
 
-        df = df.Filter(
-            "((nMuon_Loose + nElectron_Loose) == 2) &&"
-            "(nFatJets == 2)",
-            "C2: 2lep_2FJ"
-        );
+        df = definePerVariationPassFlags(df, "2lep_2FJ", [](const std::string& sfx){
+            const std::string n = sfx.empty() ? "nFatJets" : "nFatJets_" + sfx;
+            return "((nMuon_Loose + nElectron_Loose) == 2) && (" + n + " == 2)";
+        });
+        df = df.Filter(orPassExpr("2lep_2FJ"), "C2: 2lep_2FJ");
     }
 
 

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -216,18 +216,25 @@ RNode AK4JetsSelection(RNode df_, bool cleanAgainstFJ, std::string affix)
     // Downstream coffea uses Jet_isGood (nominal) and Jet_isGood_<sfx> (variations)
     // uniformly to construct jet collections from the shared Jet_* arrays.
     //
-    // NOTE: the per-variation masks use ak4GoodJetSelectionExpr, which does NOT include
-    // the fat-jet cleaning cut applied to the nominal "jet" mask (_good_ak4jets) above --
-    // variation masks preserve the pre-refactor JES definition (no FJ cleaning).
+    // Each per-variation mask is fat-jet-cleaned against the good fat jets FOR THAT
+    // variation (FatJet_isGood_<sfx>), so Jet_isGood_<sfx> parallels the FJ-cleaned nominal
+    // Jet_isGood (= _good_ak4jets for the "jet" affix). Only the good-fatjet membership
+    // changes with the variation; the ak4-ak8 dR geometry itself is JEC-invariant (eta/phi
+    // are unchanged by JEC). VVdR returns 999 for every AK4 jet when a variation has no good
+    // fat jets, so the >0.8 cut then passes (no cleaning) -- matching the nominal fj_cut.
     //
-    // njet_<sfx> = Sum(Jet_isGood_<sfx>) parallels the nominal `njet` (defined inside
-    // applyObjectMaskNewAffix) and feeds the per-variation channel-pass flags built in
-    // runPreselection.
+    // njet_<sfx> = Sum(Jet_isGood_<sfx>) then parallels the nominal `njet` (defined inside
+    // applyObjectMaskNewAffix, also FJ-cleaned) and feeds the per-variation channel-pass flags.
     if (affix == "jet") {
         df = df.Define("Jet_isGood", "_good_ak4jets");
         for (const auto& sfx : jesVariationSuffixes()) {
+            df = df.Define("_fatjet_eta_" + sfx, "FatJet_eta[FatJet_isGood_" + sfx + "]");
+            df = df.Define("_fatjet_phi_" + sfx, "FatJet_phi[FatJet_isGood_" + sfx + "]");
+            df = df.Define("_dR_ak4_fatjet_" + sfx, VVdR,
+                           {"Jet_eta", "Jet_phi", "_fatjet_eta_" + sfx, "_fatjet_phi_" + sfx});
             df = df.Define("Jet_isGood_" + sfx,
-                           ak4GoodJetSelectionExpr("Jet_pt_" + sfx) + " && !Jet_vetoMap");
+                           ak4GoodJetSelectionExpr("Jet_pt_" + sfx)
+                               + " && !Jet_vetoMap && _dR_ak4_fatjet_" + sfx + " > 0.8");
             df = df.Define("njet_" + sfx, "Sum(Jet_isGood_" + sfx + ")");
         }
     }

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -1,6 +1,29 @@
 #include "selections.h"
 #include "cutflow.h"
 
+namespace {
+// AK4 good-jet selection as a string template, parametrised by the pt-column name.
+// Used for both the nominal mask (Jet_pt) and the per-source JES variations
+// (Jet_pt_jesAbsoluteUp, ...). Must be combined with `&& !Jet_vetoMap` after the veto
+// map has been applied (the nominal path does this via Redefine; the variation loop
+// appends it explicitly).
+inline std::string ak4GoodJetSelectionExpr(const std::string& ptCol) {
+    return "_dR_ak4_lep > 0.4 &&"
+           "((isRun3 && ((" + ptCol + " > 20 && (abs(Jet_eta) <= 2.5 || abs(Jet_eta) >= 3.0) && abs(Jet_eta) < 5.0) || "
+                        "(" + ptCol + " > 50 && abs(Jet_eta) > 2.5 && abs(Jet_eta) < 3.0))) ||"
+           "(isRun2 && " + ptCol + " > 20 && abs(Jet_eta) < 5.0)) &&  "
+           "(Jet_jetId >= 2)";
+}
+
+inline std::string ak8GoodJetSelectionExpr(const std::string& ptCol) {
+    return "_dR_ak8_lep > 0.8 && "
+           + ptCol + " > 250 && "
+           "abs(FatJet_eta) <= 2.5 && "
+           "FatJet_msoftdrop > 40 && "
+           "FatJet_jetId > 0";
+}
+} // anonymous namespace
+
 // MET filters
 // https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2
 RNode METFilters(RNode df_) {
@@ -161,6 +184,23 @@ RNode AK4JetsSelection(RNode df_, bool cleanAgainstFJ, std::string affix)
 
     df = applyObjectMaskNewAffix(df, "_good_ak4jets", "Jet", affix);
     df = df.Define("ht_" + affix, "Sum(" + affix + "_pt)");
+
+    // Per-variation good-jet masks at the all-jet level (capital). Same selection logic
+    // as nominal but with Jet_pt swapped for the JES-shifted column. Defined once,
+    // alongside the primary FJ-cleaned "jet" collection. NOTE: these use
+    // ak4GoodJetSelectionExpr, which does NOT include the fat-jet cleaning cut applied to
+    // the nominal "jet" collection above -- variation masks preserve the pre-refactor JES
+    // definition (no FJ cleaning). Stored on the snapshot so downstream coffea can
+    // construct per-variation jet collections from the single-copy capital Jet_*
+    // attributes (eta, phi, btag, ...) plus per-variation Jet_pt_<sfx> / Jet_mass_<sfx> +
+    // Jet_isGood_<sfx>. Defined AFTER applyObjectMaskNewAffix so they don't get
+    // nominal-masked into lowercase aliases.
+    if (affix == "jet") {
+        for (const auto& sfx : jesVariationSuffixes()) {
+            df = df.Define("Jet_isGood_" + sfx,
+                           ak4GoodJetSelectionExpr("Jet_pt_" + sfx) + " && !Jet_vetoMap");
+        }
+    }
     return df;
 }
 
@@ -178,16 +218,18 @@ RNode AK4JetProperties(RNode df_)
 RNode AK8JetsSelection(RNode df_)
 {
     auto df = df_.Define("_dR_ak8_lep", VVdR, {"FatJet_eta", "FatJet_phi", "lepton_eta", "lepton_phi"})
-                  .Define("_good_ak8jets", "_dR_ak8_lep > 0.8 && "
-                                           "FatJet_pt > 250 && "
-                                           "abs(FatJet_eta) <= 2.5 && "
-                                           "FatJet_msoftdrop > 40 && "
-                                           "FatJet_jetId > 0")
+                  .Define("_good_ak8jets", ak8GoodJetSelectionExpr("FatJet_pt"))
                   .Define("nFatJets", "Sum(_good_ak8jets)");
 
     df = applyObjectMaskNewAffix(df, "_good_ak8jets", "FatJet", "fatjet");
     df = df.Define("ht_fatjets", "Sum(fatjet_pt)");
 
+    // Per-variation good-fatjet masks. JES affects FatJet_pt only; FatJet_msoftdrop is
+    // unchanged (its own JEC recipe lives in [[softdrop_mass_jec_recipe]]). Defined AFTER
+    // applyObjectMaskNewAffix for the same reason as the AK4 case.
+    for (const auto& sfx : jesVariationSuffixes()) {
+        df = df.Define("FatJet_isGood_" + sfx, ak8GoodJetSelectionExpr("FatJet_pt_" + sfx));
+    }
     return df;
 }
 

--- a/preselection/src/selections.cpp
+++ b/preselection/src/selections.cpp
@@ -23,9 +23,23 @@ inline std::string ak8GoodJetSelectionExpr(const std::string& ptCol) {
            "FatJet_jetId > 0";
 }
 
+// Kinematic-variation suffixes (JES + JER) whose varied jet columns actually exist in
+// this graph. Presence-checked rather than assumed: variations are MC-only (and only
+// with systematics enabled), so on data or with --no_systs this returns empty and the
+// selection stays nominal-only. Deriving the set from the columns the correction path
+// actually defined means there is no flag to keep in sync with that path.
+inline std::vector<std::string> activeKinVariations(RNode df) {
+    std::vector<std::string> out;
+    for (const auto& sfx : kinematicVariationSuffixes()) {
+        if (df.HasColumn("Jet_pt_" + sfx) && df.HasColumn("FatJet_pt_" + sfx))
+            out.push_back(sfx);
+    }
+    return out;
+}
+
 // Per-variation channel-pass-flag generation. Each channel filter that depends on a
 // jet-multiplicity cut emits a boolean per event for each variation v ∈ {nom} ∪
-// jesVariationSuffixes() — passes_<channel>_<v> — then the channel filter is OR over
+// activeKinVariations() — passes_<channel>_<v> — then the channel filter is OR over
 // those flags. This keeps events that pass the channel under ANY variation, which is
 // the only way a single output file can carry per-variation histograms downstream.
 //
@@ -34,15 +48,15 @@ inline std::string ak8GoodJetSelectionExpr(const std::string& ptCol) {
 template <typename F>
 RNode definePerVariationPassFlags(RNode df, const std::string& channel, F&& expr_for) {
     df = df.Define("passes_" + channel + "_nom", expr_for(std::string{}));
-    for (const auto& sfx : jesVariationSuffixes()) {
+    for (const auto& sfx : activeKinVariations(df)) {
         df = df.Define("passes_" + channel + "_" + sfx, expr_for(sfx));
     }
     return df;
 }
 
-inline std::string orPassExpr(const std::string& channel) {
+inline std::string orPassExpr(RNode df, const std::string& channel) {
     std::string out = "passes_" + channel + "_nom";
-    for (const auto& sfx : jesVariationSuffixes()) {
+    for (const auto& sfx : activeKinVariations(df)) {
         out += " || passes_" + channel + "_" + sfx;
     }
     return out;
@@ -227,7 +241,7 @@ RNode AK4JetsSelection(RNode df_, bool cleanAgainstFJ, std::string affix)
     // applyObjectMaskNewAffix, also FJ-cleaned) and feeds the per-variation channel-pass flags.
     if (affix == "jet") {
         df = df.Define("Jet_isGood", "_good_ak4jets");
-        for (const auto& sfx : jesVariationSuffixes()) {
+        for (const auto& sfx : activeKinVariations(df)) {
             df = df.Define("_fatjet_eta_" + sfx, "FatJet_eta[FatJet_isGood_" + sfx + "]");
             df = df.Define("_fatjet_phi_" + sfx, "FatJet_phi[FatJet_isGood_" + sfx + "]");
             df = df.Define("_dR_ak4_fatjet_" + sfx, VVdR,
@@ -266,9 +280,9 @@ RNode AK8JetsSelection(RNode df_)
     df = df.Define("FatJet_isGood", "_good_ak8jets");
     df = df.Define("nFatJets",      "Sum(FatJet_isGood)");
 
-    // Per-variation good-fatjet masks. JES affects FatJet_pt only; FatJet_msoftdrop is
+    // Per-variation good-fatjet masks. JES/JER affect FatJet_pt only; FatJet_msoftdrop is
     // unchanged. Defined AFTER applyObjectMaskNewAffix for the same reason as the AK4 case.
-    for (const auto& sfx : jesVariationSuffixes()) {
+    for (const auto& sfx : activeKinVariations(df)) {
         df = df.Define("FatJet_isGood_" + sfx, ak8GoodJetSelectionExpr("FatJet_pt_" + sfx));
         df = df.Define("nFatJets_" + sfx, "Sum(FatJet_isGood_" + sfx + ")");
     }
@@ -344,7 +358,7 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
             const std::string n = sfx.empty() ? "nFatJets" : "nFatJets_" + sfx;
             return "((nMuon_Loose == 0) && (nElectron_Loose == 0)) && (" + n + " == 0)";
         });
-        df = df.Filter(orPassExpr("0lep_0FJ"), "C2: 0lep_0FJ");
+        df = df.Filter(orPassExpr(df, "0lep_0FJ"), "C2: 0lep_0FJ");
 
         df = df.Define("met_significance", "PuppiMET_significance")
                 .Define("met_uncorrPt", "PuppiMET_pt")
@@ -364,7 +378,7 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
             const std::string n = sfx.empty() ? "nFatJets" : "nFatJets_" + sfx;
             return "((nMuon_Loose == 0) && (nElectron_Loose == 0)) && (" + n + " == 1)";
         });
-        df = df.Filter(orPassExpr("0lep_1FJ"), "C2: 0lep_1FJ");
+        df = df.Filter(orPassExpr(df, "0lep_1FJ"), "C2: 0lep_1FJ");
 
         df = df.DefaultValueFor("Pileup_nTrueInt", (float)-1.f)
                 .Define("met_significance", "PuppiMET_significance")
@@ -388,7 +402,7 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
             const std::string n = sfx.empty() ? "nFatJets" : "nFatJets_" + sfx;
             return "((nMuon_Loose == 0) && (nElectron_Loose == 0)) && (" + n + " == 1)";
         });
-        df = df.Filter(orPassExpr("0lep_1FJ_met"), "C2: 0lep_1FJ");
+        df = df.Filter(orPassExpr(df, "0lep_1FJ_met"), "C2: 0lep_1FJ");
     }
 
     // 0lep_2FJ
@@ -404,7 +418,7 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
             const std::string n = sfx.empty() ? "nFatJets" : "nFatJets_" + sfx;
             return "((nMuon_Loose == 0) && (nElectron_Loose == 0)) && (" + n + " == 2)";
         });
-        df = df.Filter(orPassExpr("0lep_2FJ"), "C2: 0lep_2FJ");
+        df = df.Filter(orPassExpr(df, "0lep_2FJ"), "C2: 0lep_2FJ");
 
         df = df.DefaultValueFor("Pileup_nTrueInt", (float)-1.f)
                 .Define("met_significance", "PuppiMET_significance")
@@ -427,7 +441,7 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
             const std::string n = sfx.empty() ? "nFatJets" : "nFatJets_" + sfx;
             return "((nMuon_Loose == 0) && (nElectron_Loose == 0)) && (" + n + " == 2)";
         });
-        df = df.Filter(orPassExpr("0lep_2FJ_met"), "C2: 0lep_2FJ");
+        df = df.Filter(orPassExpr(df, "0lep_2FJ_met"), "C2: 0lep_2FJ");
     }
 
     // 0lep_3FJ
@@ -443,7 +457,7 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
             const std::string n = sfx.empty() ? "nFatJets" : "nFatJets_" + sfx;
             return "((nMuon_Loose == 0) && (nElectron_Loose == 0)) && (" + n + " == 3)";
         });
-        df = df.Filter(orPassExpr("0lep_3FJ"), "C2: 0lep_3FJ");
+        df = df.Filter(orPassExpr(df, "0lep_3FJ"), "C2: 0lep_3FJ");
     }
 
     // 1lep_1FJ — fatjet + njet cuts must combine inside a single per-variation pass flag,
@@ -468,7 +482,7 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
             const std::string j  = sfx.empty() ? "njet"     : "njet_"     + sfx;
             return "(" + fj + " == 1) && (" + j + " >= 4)";
         });
-        df = df.Filter(orPassExpr("1lep_1FJ"), "C3: jet selection (any variation)");
+        df = df.Filter(orPassExpr(df, "1lep_1FJ"), "C3: jet selection (any variation)");
     }
 
     // 1lep_2FJ — same caveat as 1lep_1FJ (C3 + C4 collapsed).
@@ -494,7 +508,7 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
             const std::string j  = sfx.empty() ? "njet"     : "njet_"     + sfx;
             return "(" + fj + " >= 2) && (" + j + " >= 2)";
         });
-        df = df.Filter(orPassExpr("1lep_2FJ"), "C3: jet selection (any variation)");
+        df = df.Filter(orPassExpr(df, "1lep_2FJ"), "C3: jet selection (any variation)");
     }
 
     // 2lepSS
@@ -526,7 +540,7 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
             const std::string n = sfx.empty() ? "nFatJets" : "nFatJets_" + sfx;
             return "((nMuon_Loose + nElectron_Loose) == 2) && (" + n + " == 1)";
         });
-        df = df.Filter(orPassExpr("2lep_1FJ"), "C2: 2lep_1FJ");
+        df = df.Filter(orPassExpr(df, "2lep_1FJ"), "C2: 2lep_1FJ");
     }
 
     // 2lep_2FJ
@@ -542,7 +556,7 @@ RNode runPreselection(RNode df_, std::string channel, bool noCut)
             const std::string n = sfx.empty() ? "nFatJets" : "nFatJets_" + sfx;
             return "((nMuon_Loose + nElectron_Loose) == 2) && (" + n + " == 2)";
         });
-        df = df.Filter(orPassExpr("2lep_2FJ"), "C2: 2lep_2FJ");
+        df = df.Filter(orPassExpr(df, "2lep_2FJ"), "C2: 2lep_2FJ");
     }
 
 

--- a/preselection/src/utils.cpp
+++ b/preselection/src/utils.cpp
@@ -72,6 +72,16 @@ RNode applyObjectMaskNewAffix(RNode df, const std::string &maskName, const std::
         if (colName.starts_with(objectName + "_"))
         {
             std::string suffix = colName.substr(objectName.size() + 1);
+            // Skip per-source systematic-variation columns. Those carry their own per-
+            // variation good-jet masks (Jet_isGood_jes*) and downstream coffea reads them
+            // at the all-jet level, so they must NOT be aliased through the nominal mask.
+            if (suffix.find("_jes") != std::string::npos
+                || suffix.find("_jer") != std::string::npos
+                || suffix.find("_jms") != std::string::npos
+                || suffix.find("_jmr") != std::string::npos
+                || suffix.find("_unclust") != std::string::npos) {
+                continue;
+            }
             std::string newCol = newAffix + "_" + suffix;
             df = df.Define(newCol, colName + "[" + maskName + "]");
         }
@@ -374,13 +384,27 @@ void saveSnapshot(RNode df, const std::string &outputDir, const std::string &out
     final_variables.push_back("luminosityBlock");
     final_variables.push_back("event");
 
-    // do not store branches that start with "_" nor raw NanoAOD collections
+    // Drop internal RDF helpers ("_*") and the raw lepton collections (Electron_, Muon_)
+    // — leptons live under the lowercase aliases (electron_, muon_) defined by the
+    // selection step. Capital Jet_* / FatJet_* are kept in full so downstream coffea can
+    // construct per-variation jet collections from the all-jet-level attributes plus the
+    // per-variation good-jet booleans (Jet_isGood_jes*, FatJet_isGood_jes*) defined in
+    // selections.cpp. The lowercase jet_* / fatjet_* nominal-good-jets aliases are also
+    // kept (existing analysis code reads through them).
     for (auto &&ColName : ColNames) {
-        if (ColName.starts_with("_") || ColName.starts_with("Jet") || ColName.starts_with("FatJet_") || ColName.starts_with("Electron_") || ColName.starts_with("Muon_"))
-        {
-            continue;
-        }
+        if (ColName.starts_with("_")) continue;
+        if (ColName.starts_with("Electron_") || ColName.starts_with("Muon_")) continue;
         final_variables.push_back(ColName);
+    }
+
+    // Pull in the raw NanoAOD capital Jet_* / FatJet_* attributes (which are not in the
+    // Defined-columns list above). Keep all of them — option-A storage layout.
+    auto allColNames = df.GetColumnNames();
+    for (auto &&col : allColNames) {
+        if ((col.starts_with("Jet_") || col.starts_with("FatJet_")) &&
+            std::find(final_variables.begin(), final_variables.end(), col) == final_variables.end()) {
+            final_variables.push_back(col);
+        }
     }
 
     // Optionally store HLT branches from input NanoAOD, providing default values
@@ -399,6 +423,8 @@ void saveSnapshot(RNode df, const std::string &outputDir, const std::string &out
     if (isSig) {
         final_variables.push_back("LHEReweightingWeight");
         final_variables.push_back("nLHEReweightingWeight");
+        final_variables.push_back("LHEPdfWeight");
+        final_variables.push_back("nLHEPdfWeight");
     }
 
     // store all columns from input nanoAOD tree

--- a/preselection/src/utils.cpp
+++ b/preselection/src/utils.cpp
@@ -431,6 +431,9 @@ void saveSnapshot(RNode df, const std::string &outputDir, const std::string &out
     if (dumpInput) {
         auto nanoColNames = df.GetColumnNames();
         for (auto &&colName : nanoColNames) {
+            // Skip internal "_"-prefixed helper columns: input NanoAOD branches never start with
+            // "_", and some helpers (e.g. the Type-1 MET blocks/pairs) have no ROOT dictionary.
+            if (colName.starts_with("_")) continue;
             if ((std::find(final_variables.begin(), final_variables.end(), colName) == final_variables.end()) &&
                 (colName.find("HLT") == std::string::npos) && (colName.find("L1") == std::string::npos)) {
                 final_variables.push_back(colName);

--- a/preselection/src/utils.cpp
+++ b/preselection/src/utils.cpp
@@ -337,11 +337,31 @@ RVec<float> VBSBDTInfer(RVec<float> Jet_pt, RVec<float> Jet_eta, RVec<float> Jet
     }
     auto max_score_idx = std::distance(scores.begin(), std::max_element(scores.begin(), scores.end()));
     if (scores.size() > 0) {
-        return RVec<float>{static_cast<float>(combination_idxs[0][max_score_idx]), 
+        return RVec<float>{static_cast<float>(combination_idxs[0][max_score_idx]),
                          static_cast<float>(combination_idxs[1][max_score_idx]),
                          scores[max_score_idx]};
     }
     return RVec<float>{-1, -1, -1};
+}
+
+// VBS tagging on the subset of jets selected by `isGood`, with the returned pair
+// indices mapped back into the all-jet (NanoAOD Jet_*) frame, so they dereference
+// Jet_pt_<sfx>/Jet_eta/... directly without needing the mask downstream.
+// Returns {jet1_JetIdx, jet2_JetIdx, score}; {-1, -1, -999} if fewer than 2 good jets
+// (score sentinel deliberately outside the BDT output range).
+RVec<float> VBSBDTInferMasked(const RVec<int>& isGood, const RVec<float>& Jet_pt, const RVec<float>& Jet_eta, const RVec<float>& Jet_phi, const RVec<float>& Jet_mass, bool isRun2) {
+    auto idx = ROOT::VecOps::Nonzero(isGood);
+    if (idx.size() < 2) {
+        return RVec<float>{-1, -1, -999};
+    }
+    auto pair = VBSBDTInfer(ROOT::VecOps::Take(Jet_pt, idx), ROOT::VecOps::Take(Jet_eta, idx),
+                            ROOT::VecOps::Take(Jet_phi, idx), ROOT::VecOps::Take(Jet_mass, idx), isRun2);
+    if (pair[0] < 0) {
+        return RVec<float>{-1, -1, -999};
+    }
+    return RVec<float>{static_cast<float>(idx[static_cast<size_t>(pair[0])]),
+                       static_cast<float>(idx[static_cast<size_t>(pair[1])]),
+                       pair[2]};
 }
 
 /*

--- a/preselection/src/utils.h
+++ b/preselection/src/utils.h
@@ -138,6 +138,7 @@ RVec<RVec<int>> getVBSPairs(const RVec<int>& goodJets, const RVec<float>& jetPt)
 RVec<int> VBS_MaxEtaJJ(RVec<float> Jet_pt, RVec<float> Jet_eta, RVec<float> Jet_phi, RVec<float> Jet_mass);
 
 RVec<float> VBSBDTInfer(RVec<float> Jet_pt, RVec<float> Jet_eta, RVec<float> Jet_phi, RVec<float> Jet_mass, bool isRun2);
+RVec<float> VBSBDTInferMasked(const RVec<int>& isGood, const RVec<float>& Jet_pt, const RVec<float>& Jet_eta, const RVec<float>& Jet_phi, const RVec<float>& Jet_mass, bool isRun2);
 const static TMVA::Experimental::RBDT bdt("VBS BDT", "bdt/BDT_Weights.root");
 
 /*

--- a/preselection/src/weights.cpp
+++ b/preselection/src/weights.cpp
@@ -37,7 +37,7 @@ RNode applyPileupScaleFactors(std::unordered_map<std::string, correction::Correc
         pileup_weights.push_back(correctionset->evaluate({ntrueint, "down"}));
         return pileup_weights;
     };
-    return df.Define("weight_pileup", eval_correction, {"year", "Pileup_nTrueInt"});
+    return df.Define("weightsyst_pileup", eval_correction, {"year", "Pileup_nTrueInt"});
 }
 
 /*
@@ -70,7 +70,7 @@ RNode applyMuonIDScaleFactors(std::unordered_map<std::string, correction::Correc
         }
         return muon_sf_weights;
     };
-    return df.Define("weight_muonid", eval_correction, {"year", "muon_eta", "muon_pt"});
+    return df.Define("weightsyst_muonid", eval_correction, {"year", "muon_eta", "muon_pt"});
 }
 
 RNode applyMuonRecoScaleFactors(std::unordered_map<std::string, correction::CorrectionSet> cset_muon, std::unordered_map<std::string, std::string> year_map, RNode df) {
@@ -97,7 +97,7 @@ RNode applyMuonRecoScaleFactors(std::unordered_map<std::string, correction::Corr
         }
         return muon_sf_weights;
     };
-    return df.Define("weight_muonreco", eval_correction, {"year", "muon_eta", "muon_pt"});
+    return df.Define("weightsyst_muonreco", eval_correction, {"year", "muon_eta", "muon_pt"});
 }
 
 RNode applyMuonTriggerScaleFactors(std::unordered_map<std::string, correction::CorrectionSet> cset_muon, std::unordered_map<std::string, std::string> year_map, RNode df) {
@@ -124,7 +124,7 @@ RNode applyMuonTriggerScaleFactors(std::unordered_map<std::string, correction::C
         }
         return muon_sf_weights;
     };
-    return df.Define("weight_muontrigger", eval_correction, {"year", "muon_eta", "muon_pt"});
+    return df.Define("weightsyst_muontrigger", eval_correction, {"year", "muon_eta", "muon_pt"});
 }
 
 /*
@@ -155,7 +155,7 @@ RNode applyElectronIDScaleFactors(std::unordered_map<std::string, correction::Co
         }
         return electron_sf_weights;
     };
-    return df.Define("weight_electronid", eval_correction, {"year", "electron_SC_eta", "electron_pt"});
+    return df.Define("weightsyst_electronid", eval_correction, {"year", "electron_SC_eta", "electron_pt"});
 }
 
 RNode applyElectronRecoScaleFactors(std::unordered_map<std::string, correction::CorrectionSet> cset_electron, std::unordered_map<std::string, std::string> year_map, RNode df) {
@@ -210,7 +210,7 @@ RNode applyElectronRecoScaleFactors(std::unordered_map<std::string, correction::
         }
         return electron_sf_weights;
     };
-    return df.Define("weight_electronreco", eval_correction, {"year", "electron_SC_eta", "electron_pt"});
+    return df.Define("weightsyst_electronreco", eval_correction, {"year", "electron_SC_eta", "electron_pt"});
 }
 
 RNode applyElectronTriggerScaleFactors(std::unordered_map<std::string, correction::CorrectionSet> cset_electron, std::unordered_map<std::string, std::string> year_map, RNode df) {
@@ -235,7 +235,7 @@ RNode applyElectronTriggerScaleFactors(std::unordered_map<std::string, correctio
         }
         return electron_sf_weights;
     };
-    return df.Define("weight_electrontrigger", eval_correction, {"year", "electron_SC_eta", "electron_pt"});
+    return df.Define("weightsyst_electrontrigger", eval_correction, {"year", "electron_SC_eta", "electron_pt"});
 }
 
 /*
@@ -364,8 +364,8 @@ RNode applyBTaggingScaleFactors(std::unordered_map<std::string, correction::Corr
         return calc_btag_sf(year, eta, pt, jetflavor, corrname_it->second, false);
     };
 
-    // return df.Define("weight_btagging_sf_HF", eval_HF, {"year", "GnTBJet_eta", "GnTBJet_pt", "GnTBJet_hadronFlavour"})
-            //  .Define("weight_btagging_sf_LF", eval_LF, {"year", "GnTBJet_eta", "GnTBJet_pt", "GnTBJet_hadronFlavour"});
+    // return df.Define("weightsyst_btagging_sf_HF", eval_HF, {"year", "GnTBJet_eta", "GnTBJet_pt", "GnTBJet_hadronFlavour"})
+            //  .Define("weightsyst_btagging_sf_LF", eval_LF, {"year", "GnTBJet_eta", "GnTBJet_pt", "GnTBJet_hadronFlavour"});
     return df;
 }
 
@@ -416,7 +416,7 @@ RNode applyEWKCorrections(correction::CorrectionSet cset_ewk, RNode df){
             else return 1.;
         }
     };
-    return df.Define("weight_ewk", eval_correction, {"LHEPart_pt", "LHEPart_eta", "LHEPart_phi", "LHEPart_mass", "LHEPart_pdgId", "do_ewk_corr"});
+    return df.Define("ewkweight", eval_correction, {"LHEPart_pt", "LHEPart_eta", "LHEPart_phi", "LHEPart_mass", "LHEPart_pdgId", "do_ewk_corr"});
 }
 
 RNode applyL1PreFiringReweighting(RNode df){
@@ -425,40 +425,40 @@ RNode applyL1PreFiringReweighting(RNode df){
     auto colNames = df.GetColumnNames();
     bool hasL1Prefire = std::find(colNames.begin(), colNames.end(), std::string("L1PreFiringWeight_Nom")) != colNames.end();
     if (!hasL1Prefire) {
-        return df.Define("weight_l1prefiring", [] () { return RVec<float>{1.f, 1.f, 1.f}; }, {});
+        return df.Define("weightsyst_l1prefiring", [] () { return RVec<float>{1.f, 1.f, 1.f}; }, {});
     }
     auto eval_correction = [] (float L1prefire, float L1prefireup, float L1prefiredown) {
         return RVec<float>{L1prefire, L1prefireup, L1prefiredown};
     };
-    return df.Define("weight_l1prefiring", eval_correction, {"L1PreFiringWeight_Nom", "L1PreFiringWeight_Up", "L1PreFiringWeight_Dn"});
+    return df.Define("weightsyst_l1prefiring", eval_correction, {"L1PreFiringWeight_Nom", "L1PreFiringWeight_Up", "L1PreFiringWeight_Dn"});
 }
 
 RNode applyPSWeight_FSR(RNode df) {
     auto eval_correction = [] (const RVec<float> PSWeight) {
         return RVec<float>{1., PSWeight[1], PSWeight[3]};
     };
-    return df.Define("weight_PSFSR", eval_correction, {"PSWeight"});
+    return df.Define("weightsyst_PSFSR", eval_correction, {"PSWeight"});
 }
 
 RNode applyPSWeight_ISR(RNode df) {
     auto eval_correction = [] (const RVec<float> PSWeight) {
         return RVec<float>{1., PSWeight[0], PSWeight[2]};
     };
-    return df.Define("weight_PSISR", eval_correction, {"PSWeight"});
+    return df.Define("weightsyst_PSISR", eval_correction, {"PSWeight"});
 }
 
 RNode applyLHEScaleWeight_muF(RNode df) {
     auto eval_correction = [] (const RVec<float> LHEScaleWeight) {
         return RVec<float>{1., LHEScaleWeight[5], LHEScaleWeight[3]};
     };
-    return df.Define("weight_muF", eval_correction, {"LHEScaleWeight"});
+    return df.Define("weightsyst_muF", eval_correction, {"LHEScaleWeight"});
 }
 
 RNode applyLHEScaleWeight_muR(RNode df) {
     auto eval_correction = [] (const RVec<float> LHEScaleWeight) {
         return RVec<float>{1., LHEScaleWeight[7], LHEScaleWeight[1]};
     };
-    return df.Define("weight_muR", eval_correction, {"LHEScaleWeight"});
+    return df.Define("weightsyst_muR", eval_correction, {"LHEScaleWeight"});
 }
 
 RNode applyDataWeights(RNode df_) {
@@ -488,7 +488,7 @@ RNode applyMCWeights(RNode df_) {
     if (hasLHEPart) {
         df = applyEWKCorrections(cset_ewk, df);
     } else {
-        df = df.Define("weight_ewk", [] () { return 1.; }, {});
+        df = df.Define("ewkweight", [] () { return 1.; }, {});
     }
 
     df = applyL1PreFiringReweighting(df);
@@ -499,25 +499,25 @@ RNode applyMCWeights(RNode df_) {
         df = applyLHEScaleWeight_muF(df);
         df = applyLHEScaleWeight_muR(df);
     } else {
-        df = df.Define("weight_muF", [] () { return RVec<float>{1.f, 1.f, 1.f}; }, {});
-        df = df.Define("weight_muR", [] () { return RVec<float>{1.f, 1.f, 1.f}; }, {});
+        df = df.Define("weightsyst_muF", [] () { return RVec<float>{1.f, 1.f, 1.f}; }, {});
+        df = df.Define("weightsyst_muR", [] () { return RVec<float>{1.f, 1.f, 1.f}; }, {});
     }
 
     return df.Redefine("weight",
         "weight *"
-        "weight_pileup[0] * "
-        "weight_muonid[0] * "
-        "weight_muonreco[0] * "
-        "weight_muontrigger[0] * "
-        "weight_electronid[0] * "
-        "weight_electronreco[0] * "
-        "weight_electrontrigger[0] * "
-        // "weight_btagging_sf_HF[0] * "
-        // "weight_btagging_sf_LF[0] * "
-        "weight_ewk * "
-        "weight_l1prefiring[0] * "
-        "weight_PSISR[0] * "
-        "weight_PSFSR[0] * "
-        "weight_muF[0] * "
-        "weight_muR[0]");
+        "weightsyst_pileup[0] * "
+        "weightsyst_muonid[0] * "
+        "weightsyst_muonreco[0] * "
+        "weightsyst_muontrigger[0] * "
+        "weightsyst_electronid[0] * "
+        "weightsyst_electronreco[0] * "
+        "weightsyst_electrontrigger[0] * "
+        // "weightsyst_btagging_sf_HF[0] * "
+        // "weightsyst_btagging_sf_LF[0] * "
+        "ewkweight * "
+        "weightsyst_l1prefiring[0] * "
+        "weightsyst_PSISR[0] * "
+        "weightsyst_PSFSR[0] * "
+        "weightsyst_muF[0] * "
+        "weightsyst_muR[0]");
 }

--- a/preselection/src/weights.cpp
+++ b/preselection/src/weights.cpp
@@ -420,12 +420,17 @@ RNode applyEWKCorrections(correction::CorrectionSet cset_ewk, RNode df){
 }
 
 RNode applyL1PreFiringReweighting(RNode df){
+    // L1PreFiringWeight_* branches are only present in Run 2 NanoAOD; the
+    // correction does not apply to Run 3, so emit a unit weight there.
+    auto colNames = df.GetColumnNames();
+    bool hasL1Prefire = std::find(colNames.begin(), colNames.end(), std::string("L1PreFiringWeight_Nom")) != colNames.end();
+    if (!hasL1Prefire) {
+        return df.Define("weight_l1prefiring", [] () { return RVec<float>{1.f, 1.f, 1.f}; }, {});
+    }
     auto eval_correction = [] (float L1prefire, float L1prefireup, float L1prefiredown) {
         return RVec<float>{L1prefire, L1prefireup, L1prefiredown};
     };
-    // TODO: check what this is in v15
-    // return df.Define("weight_l1prefiring", eval_correction, {"L1PreFiringWeight_Nom", "L1PreFiringWeight_Up", "L1PreFiringWeight_Dn"});
-    return df;
+    return df.Define("weight_l1prefiring", eval_correction, {"L1PreFiringWeight_Nom", "L1PreFiringWeight_Up", "L1PreFiringWeight_Dn"});
 }
 
 RNode applyPSWeight_FSR(RNode df) {
@@ -510,7 +515,7 @@ RNode applyMCWeights(RNode df_) {
         // "weight_btagging_sf_HF[0] * "
         // "weight_btagging_sf_LF[0] * "
         "weight_ewk * "
-        // "weight_l1prefiring[0] * "
+        "weight_l1prefiring[0] * "
         "weight_PSISR[0] * "
         "weight_PSFSR[0] * "
         "weight_muF[0] * "


### PR DESCRIPTION
This branch is a rework of the corrections and systematics workflow. It rebuilds the nominal jet-energy corrections from scratch to follow the current JME-recommended application chain, then adds the systematic variations on top: per-source JES uncertainties, JER up/down, and Type-1 PuppiMET. It also adds the remaining event weights (L1 pre-firing, µF/µR, PS ISR/FSR) and standardizes weight-branch and jet-collection naming.

The JEC/JER/MET application follows the central CMS JERC recommendations and tutorial (cms-analysis/jme/jerc-application-tutorial, JecApplication.cpp / JecApplication.py):

- JME recommendations (JES/JER tags): https://cms-jerc.web.cern.ch/Recommendations/
- Type-1 MET recipe: https://cms-jerc.web.cern.ch/Type1MET/
- Tutorial: https://gitlab.cern.ch/cms-analysis/jme/jerc-application-tutorial

## Jet-energy corrections (JEC/JER) and Type-I MET
- Reworked the nominal JEC/JER application from scratch to match the JME-recommended chain.
- Updated json retrieval to pin a specific version, instead of loading from `latest`.
- We apply the jet energy scale (JES) before the resolution smearing (JER), following the tutorial's order.
- Fixed how the random JER smearing is applied so that the random number a jet gets no longer changes between the nominal and the systematic variations. This diverges from the tutorial, as it passes the raw jet pt as random seed, as opposed to the corrected jet pt. However, this is more correct, as previously the random seed would change per JES, adding noise to the up/down variations, while now the differences reflect real physics only.
- MET is now rebuilt from scratch from RawPuppiMET using the official JERC recipe

## Weights
- Added L1 pre-firing reweighting (with a safe fallback when the input branches are absent, i.e. for Run 3), plus the µF/µR and PS ISR/FSR weights.
- Rename weight scale-factor branches to a weightsyst_ prefix (pileup, muon/electron ID/reco/trigger, PS ISR/FSR, µF/µR, L1 pre-firing) and rename the EWK correction branch to ewkweight. This is necessary to work with coffea downstream.

## Jet handling / variations
- Fat-jet-clean the per-variation good-AK4 masks against the corresponding per-variation fat jets.
- Each channel's jet-multiplicity selection now emits a per-variation pass flag (`passes_<channel>_<nom|jesSource>`) and the channel filter is the OR of all of them, so an event is kept if it passes under any JES variation 
- Add an option to run nominal-only.
-  Variations are propagated to VBS jets tagger selection

## Fixes
- Correct jetID usage for 2016 (should not have any effect). 

##  Not yet applied (code present, disabled/unwired):
- JMR/JMS: helpers implemented but unwired; awaiting the GloParT mass calibration inputs.
- Unclustered MET corrections: function implemented but not called anywhere yet. To be checked.
- MET phi corrections: wired and active for Run 2, but a no-op for Run 3 (Run 3 JSONs commented out); nominal-only, not applied to JES variations.

##  Implemented & active, pending revalidation:
 - Jet veto maps: applied to good-AK4 selection (nominal + per-variation) and as a Run 3 event filter, for all years incl. 2024; to be re-checked against the latest recommendations, including 2025.
